### PR TITLE
Tidy up spacing around the header + content

### DIFF
--- a/block-template-parts/footer.html
+++ b/block-template-parts/footer.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"1.25rem","top":"8rem","right":"1.25rem","left":"1.25rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignwide" style="padding-top:8rem;padding-right:1.25rem;padding-bottom:1.25rem;padding-left:1.25rem"><!-- wp:site-title /-->
+<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"max(1.25rem, 5vw)","top":"8rem","right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignwide" style="padding-top:8rem;padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:site-title /-->
 
 <!-- wp:paragraph {"align":"right"} -->
 <p class="has-text-align-right">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>

--- a/block-template-parts/header-large-dark.html
+++ b/block-template-parts/header-large-dark.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background has-link-color"><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
+<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide"><!-- wp:group {"layout":{"type":"flex"}} -->
 <div class="wp-block-group"><!-- wp:site-logo {"width":64} /-->
 
@@ -11,10 +11,6 @@
 <!-- /wp:navigation --></div>
 <!-- /wp:group -->
 
-<!-- wp:spacer {"height":128} -->
-<div style="height:128px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
 <!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column -->
 <div class="wp-block-column"><!-- wp:site-tagline {"style":{"typography":{"fontFamily":"var:preset|font-family|source-serif-pro","fontWeight":"300","fontSize":"clamp(4rem, 8vw, 6.25rem)","lineHeight":"1.15"}}} /--></div>
@@ -22,6 +18,6 @@
 <!-- /wp:columns --></div>
 <!-- /wp:group -->
 
-<!-- wp:spacer {"height":128} -->
-<div style="height:128px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":64} -->
+<div style="height:64px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/block-template-parts/header.html
+++ b/block-template-parts/header.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"1.25rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignwide" style="padding-top:1.25rem;padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
+<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
 <div class="wp-block-group">
 <!-- wp:site-logo {"width":64} /-->
 

--- a/block-templates/404.html
+++ b/block-templates/404.html
@@ -1,7 +1,7 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","style":{"spacing":{"padding":{"right":"1.25rem","left":"1.25rem"}}},"layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"1.25rem","left":"1.25rem"}}}} -->
-<main class="wp-block-group" style="padding-right:1.25rem;padding-left:1.25rem"><!-- wp:group {"layout":{"inherit":true}} -->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}}} -->
+<main class="wp-block-group" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group"><!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center">404</p>
 <!-- /wp:paragraph -->

--- a/block-templates/front-page.html
+++ b/block-templates/front-page.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header-large-dark","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"1.25rem","left":"1.25rem"}}}} -->
-<main class="wp-block-group" style="padding-right:1.25rem;padding-left:1.25rem">
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}}} -->
+<main class="wp-block-group" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)">
 
 <!-- wp:post-content {"layout":{"inherit":true}} /--></main>
 <!-- /wp:group -->

--- a/block-templates/index.html
+++ b/block-templates/index.html
@@ -1,7 +1,7 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","style":{"spacing":{"padding":{"right":"1.25rem","left":"1.25rem"}}},"layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} /-->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"right":"1.25rem","left":"1.25rem"}}}} -->
-<div class="wp-block-group" style="padding-right:1.25rem;padding-left:1.25rem"><!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":10},"tagName":"main","displayLayout":{"type":"flex","columns":3},"layout":{"inherit":true}} -->
+<!-- wp:group {"style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}}} -->
+<div class="wp-block-group" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":10},"tagName":"main","displayLayout":{"type":"flex","columns":3},"layout":{"inherit":true}} -->
 <main class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
 <!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 

--- a/block-templates/page.html
+++ b/block-templates/page.html
@@ -1,7 +1,7 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","style":{"spacing":{"padding":{"right":"1.25rem","left":"1.25rem"}}},"layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"1.25rem","left":"1.25rem"}}}} -->
-<main class="wp-block-group" style="padding-right:1.25rem;padding-left:1.25rem"><!-- wp:group {"layout":{"inherit":true}} -->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}}} -->
+<main class="wp-block-group" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group"><!-- wp:post-title {"align":"wide"} /-->
 
 <!-- wp:post-featured-image {"align":"wide"} /-->

--- a/block-templates/single.html
+++ b/block-templates/single.html
@@ -1,7 +1,7 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","style":{"spacing":{"padding":{"right":"1.25rem","left":"1.25rem"}}},"layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"1.25rem","left":"1.25rem"}}}} -->
-<main class="wp-block-group" style="padding-right:1.25rem;padding-left:1.25rem"><!-- wp:group {"layout":{"inherit":true}} -->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}}} -->
+<main class="wp-block-group" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group"><!-- wp:post-title {"align":"wide"} /-->
 
 <!-- wp:post-featured-image {"align":"wide"} /-->


### PR DESCRIPTION
This PR swaps some of our pixel values to `min()` values instead, so that things are spaced out more generously on desktop screens. This is closer to the original intent of the design comps. It also ensures that logo lines up with the content on the index/single pages. 

Before|After
---|---
![Screen Shot 2021-10-05 at 10 44 41](https://user-images.githubusercontent.com/1202812/136046207-2fe38595-eb14-4b95-a38e-858784f6ac8d.png)|![Screen Shot 2021-10-05 at 10 44 18](https://user-images.githubusercontent.com/1202812/136046249-d81ecccd-25ad-4429-a926-5f9a9034fdee.png)

Before|After
---|---
![Screen Shot 2021-10-05 at 10 44 34](https://user-images.githubusercontent.com/1202812/136046297-d277e55c-4718-44fb-bf45-cddec60341c3.png)|![Screen Shot 2021-10-05 at 10 44 23](https://user-images.githubusercontent.com/1202812/136046305-4b741024-e049-41fa-9791-1417c5365f64.png)