### PR TITLE
Try adding a couple CSS reset fixes

### DIFF
--- a/style.css
+++ b/style.css
@@ -15,6 +15,43 @@ Twenty Twenty-Two WordPress Theme, (C) 2021 WordPress.org
 Twenty Twenty-Two is distributed under the terms of the GNU GPL.
 */
 
+/*--------------------------------------------------------------
+>>> TABLE OF CONTENTS:
+----------------------------------------------------------------
+
+    0.  CSS Reset
+    1.  Fonts
+
+----------------------------------------------------------------------------- */
+
+/* -------------------------------------------------------------------------- */
+/*  0. CSS Reset
+/* -------------------------------------------------------------------------- */
+
+/* 
+ * Required until Gutenberg issue is resolved:
+ * https://github.com/WordPress/gutenberg/issues/35350
+ */
+body {
+    margin: 0;
+}
+
+/* 
+ * Required until Gutenberg issue is resolved:
+ * https://github.com/WordPress/gutenberg/issues/35353
+ */
+*[class^="wp-container"] > style:first-child + * {
+    margin-top: 0 !important;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  1. Fonts
+/* -------------------------------------------------------------------------- */
+
+/* 
+ * Fonts can be reworked if this core issue is resolved:
+ * https://github.com/WordPress/wordpress-develop/pull/1573
+ */
 @font-face{
     font-family: 'Source Serif Pro';
     font-weight: 200 900;
@@ -33,4 +70,8 @@ Twenty Twenty-Two is distributed under the terms of the GNU GPL.
     src: url('/wp-content/themes/twentytwentytwo/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2'),
          url('/wp-content/themes/twentytwentytwo/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff') format('woff'),
          url('/wp-content/themes/twentytwentytwo/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf') format('truetype');
+}
+
+body {
+
 }


### PR DESCRIPTION
@jffng not sure if we should include these temporarily or just wait for fixes on the Gutenberg end? They're pretty glaring issues. I was sure to reference Gutenberg issues directly for each one. 

Fixes #7 

Before|After
---|---
![Screen Shot 2021-10-05 at 14 49 07](https://user-images.githubusercontent.com/1202812/136084613-4bd5344a-256a-4eb7-85ea-e330c42a28b1.png)|![Screen Shot 2021-10-05 at 14 49 00](https://user-images.githubusercontent.com/1202812/136084622-1f009690-0885-4f9d-9c8f-a7ed4d7fd95d.png)


