### PR TITLE
Ensure only a string or false can be passed to main `wp_enqueue_theme`

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -19,13 +19,13 @@ if ( ! function_exists( 'twentytwentytwo_editor_styles' ) ) :
 	/**
 	 * Enqueue scripts and styles.
 	 */
-	function twentytwentytwo_scripts() {
+	function twentytwentytwo_styles() {
 		// Enqueue theme stylesheet.
 		$theme_version  = wp_get_theme()->get( 'Version' );
 		$version_string = is_string( $theme_version ) ? $theme_version : false;
 		wp_enqueue_style( 'twentytwentytwo-style', get_template_directory_uri() . '/style.css', array(), $version_string );
 	}
-	add_action( 'wp_enqueue_scripts', 'twentytwentytwo_scripts' );
+	add_action( 'wp_enqueue_scripts', 'twentytwentytwo_styles' );
 endif;
 
 if ( ! function_exists( 'twentytwentytwo_editor_styles' ) ) :

--- a/functions.php
+++ b/functions.php
@@ -15,7 +15,7 @@ if ( ! function_exists( 'twentytwentytwo_support' ) ) :
 	add_action( 'after_setup_theme', 'twentytwentytwo_support' );
 endif;
 
-if ( ! function_exists( 'twentytwentytwo_editor_styles' ) ) :
+if ( ! function_exists( 'twentytwentytwo_styles' ) ) :
 	/**
 	 * Enqueue scripts and styles.
 	 */

--- a/functions.php
+++ b/functions.php
@@ -15,16 +15,18 @@ if ( ! function_exists( 'twentytwentytwo_support' ) ) :
 	add_action( 'after_setup_theme', 'twentytwentytwo_support' );
 endif;
 
-/**
- * Enqueue scripts and styles.
- */
-function twentytwentytwo_scripts() {
-	// Enqueue theme stylesheet.
-	$theme_version  = wp_get_theme()->get( 'Version' );
-	$version_string = is_string( $theme_version ) ? $theme_version : false;
-	wp_enqueue_style( 'twentytwentytwo-style', get_template_directory_uri() . '/style.css', array(), $version_string );
-}
-add_action( 'wp_enqueue_scripts', 'twentytwentytwo_scripts' );
+if ( ! function_exists( 'twentytwentytwo_editor_styles' ) ) :
+	/**
+	 * Enqueue scripts and styles.
+	 */
+	function twentytwentytwo_scripts() {
+		// Enqueue theme stylesheet.
+		$theme_version  = wp_get_theme()->get( 'Version' );
+		$version_string = is_string( $theme_version ) ? $theme_version : false;
+		wp_enqueue_style( 'twentytwentytwo-style', get_template_directory_uri() . '/style.css', array(), $version_string );
+	}
+	add_action( 'wp_enqueue_scripts', 'twentytwentytwo_scripts' );
+endif;
 
 if ( ! function_exists( 'twentytwentytwo_editor_styles' ) ) :
 	/**

--- a/functions.php
+++ b/functions.php
@@ -21,7 +21,9 @@ if ( ! function_exists( 'twentytwentytwo_styles' ) ) :
 	 */
 	function twentytwentytwo_styles() {
 		// Enqueue theme stylesheet.
-		wp_enqueue_style( 'twentytwentytwo-style', get_template_directory_uri() . '/style.css', array(), wp_get_theme()->get( 'Version' ) );
+		$theme_version  = wp_get_theme()->get( 'Version' );
+		$version_string = is_string( $theme_version ) ? $theme_version : false;
+		wp_enqueue_style( 'twentytwentytwo-style', get_template_directory_uri() . '/style.css', array(), $theme_version );
 	}
 	add_action( 'wp_enqueue_scripts', 'twentytwentytwo_styles' );
 endif;

--- a/functions.php
+++ b/functions.php
@@ -15,18 +15,16 @@ if ( ! function_exists( 'twentytwentytwo_support' ) ) :
 	add_action( 'after_setup_theme', 'twentytwentytwo_support' );
 endif;
 
-if ( ! function_exists( 'twentytwentytwo_styles' ) ) :
-	/**
-	 * Enqueue scripts and styles.
-	 */
-	function twentytwentytwo_styles() {
-		// Enqueue theme stylesheet.
-		$theme_version  = wp_get_theme()->get( 'Version' );
-		$version_string = is_string( $theme_version ) ? $theme_version : false;
-		wp_enqueue_style( 'twentytwentytwo-style', get_template_directory_uri() . '/style.css', array(), $theme_version );
-	}
-	add_action( 'wp_enqueue_scripts', 'twentytwentytwo_styles' );
-endif;
+/**
+ * Enqueue scripts and styles.
+ */
+function twentytwentytwo_scripts() {
+	// Enqueue theme stylesheet.
+	$theme_version  = wp_get_theme()->get( 'Version' );
+	$version_string = is_string( $theme_version ) ? $theme_version : false;
+	wp_enqueue_style( 'twentytwentytwo-style', get_template_directory_uri() . '/style.css', array(), $version_string );
+}
+add_action( 'wp_enqueue_scripts', 'twentytwentytwo_scripts' );
 
 if ( ! function_exists( 'twentytwentytwo_editor_styles' ) ) :
 	/**


### PR DESCRIPTION
Fixes #35 by verifying in advance for static analysis tooling that only valid types (in this PR it constraints it to only a string or false) will be passed to the `$version` parameter of the `wp_enqueue_style()` function for the main stylesheet.

This doesn't seem like a perfect solution but it satisfies the static analysis tool.

An alternative option would be to simply have this code flagged for ignoring this error in the static analysis tool - which is the cleaner code approach and probably acceptable here since we know the `wp_get_theme->get( 'version' );` return value better than the docblock of the function details.