### PR TITLE
Add gigantic and colossal font sizes to typography.fontSizes

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -97,6 +97,16 @@
 					"name": "Huge",
 					"size": "clamp(2.5rem, 4vw, 3rem)",
 					"slug": "huge"
+				},
+				{
+					"name": "Gigantic",
+					"size": "clamp(3rem, 6vw, 4rem)",
+					"slug": "gigantic"
+				},
+				{
+					"name": "Colossal",
+					"size": "clamp(4rem, 8vw, 6.25rem)",
+					"slug": "colossal"
 				}
 			]
 		},

--- a/theme.json
+++ b/theme.json
@@ -34,10 +34,6 @@
 		},
 		"custom": {
 			"typography": {
-				"font-size": {
-					"gigantic": "clamp(3rem, 6vw, 4rem)",
-					"colossal": "clamp(4rem, 8vw, 6.25rem)"
-				},
 				"line-height": {
 					"tiny": 1.15,
 					"small": 1.2,
@@ -131,7 +127,7 @@
 					"fontFamily": "var(--wp--preset--font-family--source-serif-pro)",
 					"fontWeight": "300",
 					"lineHeight": "var(--wp--custom--typography--line-height--tiny)",
-					"fontSize": "var(--wp--custom--typography--font-size--gigantic)"
+					"fontSize": "var(--wp--preset--font-size--gigantic)"
 				}
 			},
 			"core/site-title": {
@@ -153,7 +149,7 @@
 					"fontFamily": "var(--wp--preset--font-family--source-serif-pro)",
 					"fontWeight": "300",
 					"lineHeight": "var(--wp--custom--typography--line-height--tiny)",
-					"fontSize": "var(--wp--custom--typography--font-size--colossal)"
+					"fontSize": "var(--wp--preset--font-size--colossal)"
 				}
 			},
 			"h2": {
@@ -161,7 +157,7 @@
 					"fontFamily": "var(--wp--preset--font-family--source-serif-pro)",
 					"fontWeight": "300",
 					"lineHeight": "var(--wp--custom--typography--line-height--small)",
-					"fontSize": "var(--wp--custom--typography--font-size--gigantic)"
+					"fontSize": "var(--wp--preset--font-size--gigantic)"
 				}
 			},
 			"h3": {


### PR DESCRIPTION
Closes https://github.com/WordPress/twentytwentytwo/issues/37 by pulling the previously custom-only gigantic and colossal font sizes, into the theme's fontSizes UI. 