### PR TITLE
Replace h1 with paragraph in the footer site title

### DIFF
--- a/block-template-parts/footer.html
+++ b/block-template-parts/footer.html
@@ -1,5 +1,5 @@
 <!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"max(1.25rem, 5vw)","top":"8rem","right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignwide" style="padding-top:8rem;padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:site-title /-->
+<div class="wp-block-group alignwide" style="padding-top:8rem;padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:site-title {"level":0} /-->
 
 <!-- wp:paragraph {"align":"right"} -->
 <p class="has-text-align-right">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>


### PR DESCRIPTION
Fixes #39

Works fine on my side: the default h1 tag is replaced with a paragraph, which is more relevant in this context :)