### PR TITLE
Address floating issues on <main> element

### DIFF
--- a/block-templates/404.html
+++ b/block-templates/404.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}}} -->
-<main class="wp-block-group" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"layout":{"inherit":true}} -->
+<main class="wp-block-group" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw);overflow:hidden"><!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group"><!-- wp:heading {"style":{"typography":{"fontSize":"clamp(4rem, 40vw, 20rem)","fontWeight":"200","lineHeight":"0"}},"className":"has-text-align-center"} -->
 <h2 class="has-text-align-center" style="font-size:clamp(4rem, 40vw, 20rem);font-weight:200;line-height:0">404</h2>
 <!-- /wp:heading -->

--- a/block-templates/front-page.html
+++ b/block-templates/front-page.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header-large-dark","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}}} -->
-<main class="wp-block-group" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)">
+<main class="wp-block-group" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw);overflow:hidden">
 
 <!-- wp:post-content {"layout":{"inherit":true}} /--></main>
 <!-- /wp:group -->

--- a/block-templates/index.html
+++ b/block-templates/index.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} /-->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}}} -->
-<div class="wp-block-group" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":10},"tagName":"main","displayLayout":{"type":"flex","columns":3},"layout":{"inherit":true}} -->
+<div class="wp-block-group" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw);overflow:hidden"><!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":10},"tagName":"main","displayLayout":{"type":"flex","columns":3},"layout":{"inherit":true}} -->
 <main class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
 <!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 

--- a/block-templates/page.html
+++ b/block-templates/page.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}}} -->
-<main class="wp-block-group" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"layout":{"inherit":true}} -->
+<main class="wp-block-group" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw);overflow:hidden"><!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group"><!-- wp:post-title {"align":"wide"} /-->
 
 <!-- wp:post-featured-image {"align":"wide"} /-->

--- a/block-templates/single.html
+++ b/block-templates/single.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}}} -->
-<main class="wp-block-group" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"layout":{"inherit":true}} -->
+<main class="wp-block-group" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw);overflow:hidden"><!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group"><!-- wp:post-title {"align":"wide"} /-->
 
 <!-- wp:post-featured-image {"align":"wide"} /-->


### PR DESCRIPTION
Fixes #44 

I believe we need to add an `overflow: hidden` declaration to the `<main>` element on each template to avoid floating issues. Not sure where is the best location for this CSS declaration though.

Issue:

![screencapture-localhost-8888-twentytwentytwo-about-clearing-floats-2021-10-07-00_50_16](https://user-images.githubusercontent.com/1590998/136294350-fcc66435-d420-4ff2-a5c8-7d6b2d77d159.png)

After the proposed patch:

![screencapture-localhost-8888-twentytwentytwo-about-clearing-floats-2021-10-07-00_48_51](https://user-images.githubusercontent.com/1590998/136294434-02eebad7-89de-47f9-9900-7e377bc694db.png)
