### PR TITLE
Load editor styles correctly

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -11,6 +11,9 @@ if ( ! function_exists( 'twentytwentytwo_support' ) ) :
 
 		// Adding support for responsive embedded content.
 		add_theme_support( 'responsive-embeds' );
+
+		// Adding support for editor styles.
+		add_theme_support( 'editor-styles');
 	}
 	add_action( 'after_setup_theme', 'twentytwentytwo_support' );
 endif;
@@ -22,4 +25,17 @@ function twentytwentytwo_scripts() {
 	// Enqueue theme stylesheet.
 	wp_enqueue_style( 'twentytwentytwo-style', get_template_directory_uri() . '/style.css', array(), wp_get_theme()->get( 'Version' ) );
 }
-add_action( 'enqueue_block_assets', 'twentytwentytwo_scripts' );
+add_action( 'wp_enqueue_scripts', 'twentytwentytwo_scripts' );
+
+/**
+ * Enqueue editor styles.
+ */
+function twentytwentytwo_editor_styles() {
+	// Enqueue editor styles.
+	add_editor_style(
+		array(
+			get_stylesheet_uri(),
+		)
+	);
+}
+add_action( 'admin_init', 'twentytwentytwo_editor_styles' );

--- a/functions.php
+++ b/functions.php
@@ -22,17 +22,4 @@ function twentytwentytwo_scripts() {
 	// Enqueue theme stylesheet.
 	wp_enqueue_style( 'twentytwentytwo-style', get_template_directory_uri() . '/style.css', array(), wp_get_theme()->get( 'Version' ) );
 }
-add_action( 'wp_enqueue_scripts', 'twentytwentytwo_scripts' );
-
-/**
- * Enqueue editor styles.
- */
-function twentytwentytwo_editor_styles() {
-	// Enqueue editor styles.
-	add_editor_style(
-		array(
-			get_stylesheet_uri(),
-		)
-	);
-}
-add_action( 'admin_init', 'twentytwentytwo_editor_styles' );
+add_action( 'enqueue_block_assets', 'twentytwentytwo_scripts' );


### PR DESCRIPTION
Fixes #32 

## Note

At the moment, the editor styles are not loading. This is caused due to the function [`add_editor_style()`](https://developer.wordpress.org/reference/functions/add_editor_style/), which has a somewhat misleading name. This  function is not loading the styles for the block editor, but loads styles for the TinyMCE editor stylesheets.

I thought about two ways of resolving this problem:

- Switch hook `wp_enqueue_scripts` to `enqueue_block_assets`, to load the styles both in the frontend and editor.
- Switch hook `admin_init` to `enqueue_block_editor_assets` and replace `add_editor_style()` with `wp_enqueue_style()` within `twentytwentytwo_editor_styles()`.

I went for the first option, as it's less code, which improves both readability and maintainability of the source code.

<table>
<tr>
<td>Before:
<br><br>

![#32-before](https://user-images.githubusercontent.com/3323310/136315735-fac20b4e-ff43-4507-a2c6-72486fbe6440.png)
</td>
<td>After:
<br><br>

![#32-after](https://user-images.githubusercontent.com/3323310/136315739-e5731800-a6dc-49e9-8c71-392f867cf0eb.png)
</td>
</tr>
</table>

## Testing steps

1. Create a test page
2. Add the headlines 1-6 and save the page
3. See that Source Serif Pro is not rendered in the editor
4. Check out this PR
5. Refresh the page
6. See that Source Serif Pro is rendered in the editor

## Tip

The screenshot below shows where to see the rendered font within Chrome DevTools:

<img width="1280" alt="#32-rendered-font" src="https://user-images.githubusercontent.com/3323310/136316374-0bb9553b-f1dc-42a6-b029-17a545fe37f1.png">
