### PR TITLE
Fix font paths

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -20,8 +20,34 @@ if ( ! function_exists( 'twentytwentytwo_styles' ) ) :
 	 * Enqueue scripts and styles.
 	 */
 	function twentytwentytwo_styles() {
-		// The @font-face styles.
-		$font_face_css = "
+		// Register theme stylesheet.
+		wp_register_style( 'twentytwentytwo-style', '' );
+		// Add styles inline.
+		wp_add_inline_style( 'twentytwentytwo-style', twentytwentytwo_get_font_face_styles() );
+		// Enqueue theme stylesheet.
+		wp_enqueue_style( 'twentytwentytwo-style' );
+	}
+	add_action( 'wp_enqueue_scripts', 'twentytwentytwo_styles' );
+endif;
+
+if ( ! function_exists( 'twentytwentytwo_editor_styles' ) ) :
+	/**
+	 * Enqueue editor styles.
+	 */
+	function twentytwentytwo_editor_styles() {
+		wp_add_inline_style( 'wp-block-library', twentytwentytwo_get_font_face_styles() );
+	}
+	add_action( 'admin_init', 'twentytwentytwo_editor_styles' );
+endif;
+
+if ( ! function_exists( 'twentytwentytwo_get_font_face_styles' ) ) :
+	/**
+	 * Get font face styles.
+	 *
+	 * @return string
+	 */
+	function twentytwentytwo_get_font_face_styles() {
+		return "
 		@font-face{
 			font-family: 'Source Serif Pro';
 			font-weight: 200 900;
@@ -38,27 +64,5 @@ if ( ! function_exists( 'twentytwentytwo_styles' ) ) :
 			src: url('" . get_theme_file_uri( 'assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2' ) . "') format('woff2');
 		}
 		";
-		// Register theme stylesheet.
-		wp_register_style( 'twentytwentytwo-style', '' );
-		// Add styles inline.
-		wp_add_inline_style( 'twentytwentytwo-style', $font_face_css );
-		// Enqueue theme stylesheet.
-		wp_enqueue_style( 'twentytwentytwo-style' );
 	}
-	add_action( 'wp_enqueue_scripts', 'twentytwentytwo_styles' );
-endif;
-
-if ( ! function_exists( 'twentytwentytwo_editor_styles' ) ) :
-	/**
-	 * Enqueue editor styles.
-	 */
-	function twentytwentytwo_editor_styles() {
-		// Enqueue editor styles.
-		add_editor_style(
-			array(
-				get_stylesheet_uri(),
-			)
-		);
-	}
-	add_action( 'admin_init', 'twentytwentytwo_editor_styles' );
 endif;

--- a/functions.php
+++ b/functions.php
@@ -20,10 +20,30 @@ if ( ! function_exists( 'twentytwentytwo_styles' ) ) :
 	 * Enqueue scripts and styles.
 	 */
 	function twentytwentytwo_styles() {
+		// The @font-face styles.
+		$font_face_css = "
+		@font-face{
+			font-family: 'Source Serif Pro';
+			font-weight: 200 900;
+			font-style: normal;
+			font-stretch: normal;
+			src: url('" . get_theme_file_uri( 'assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2' ) . "') format('woff2');
+		}
+
+		@font-face{
+			font-family: 'Source Serif Pro';
+			font-weight: 200 900;
+			font-style: italic;
+			font-stretch: normal;
+			src: url('" . get_theme_file_uri( 'assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2' ) . "') format('woff2');
+		}
+		";
+		// Register theme stylesheet.
+		wp_register_style( 'twentytwentytwo-style', '' );
+		// Add styles inline.
+		wp_add_inline_style( 'twentytwentytwo-style', $font_face_css );
 		// Enqueue theme stylesheet.
-		$theme_version  = wp_get_theme()->get( 'Version' );
-		$version_string = is_string( $theme_version ) ? $theme_version : false;
-		wp_enqueue_style( 'twentytwentytwo-style', get_template_directory_uri() . '/style.css', array(), $version_string );
+		wp_enqueue_style( 'twentytwentytwo-style' );
 	}
 	add_action( 'wp_enqueue_scripts', 'twentytwentytwo_styles' );
 endif;

--- a/style.css
+++ b/style.css
@@ -14,36 +14,3 @@ Text Domain: twentytwentytwo
 Twenty Twenty-Two WordPress Theme, (C) 2021 WordPress.org
 Twenty Twenty-Two is distributed under the terms of the GNU GPL.
 */
-
-/*--------------------------------------------------------------
- >>> TABLE OF CONTENTS:
- ----------------------------------------------------------------
-
-	0. Fonts
-
- ----------------------------------------------------------------------------- */
-
-/* -------------------------------------------------------------------------- */
-/*  0. Fonts
-/* -------------------------------------------------------------------------- */
-
-/*
- * Fonts can be reworked if this core issue is resolved:
- * https://github.com/WordPress/wordpress-develop/pull/1573
- */
-
-@font-face{
-	font-family: 'Source Serif Pro';
-	font-weight: 200 900;
-	font-style: normal;
-	font-stretch: normal;
-	src: url('/wp-content/themes/twentytwentytwo/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');
-}
-
-@font-face{
-	font-family: 'Source Serif Pro';
-	font-weight: 200 900;
-	font-style: italic;
-	font-stretch: normal;
-	src: url('/wp-content/themes/twentytwentytwo/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');
-}


### PR DESCRIPTION
We can't assume that the theme will be in `wp-content/themes/twentytwentytwo`. Some sites use a different folder for wp-content, they have themes in subfolders, they might rename the theme and so on.
As a result, using URLs like `url('/wp-content/themes/twentytwentytwo/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2')` in the stylesheet has a potential to break things.

A solution to that issue would be to add the font-face styles inline. This will allow us to use PHP to get the correct URL to the theme, and avoid breaking things.

Notes:
* This PR changes `twentytwentytwo-style` from `get_template_directory_uri() . '/style.css'` to an empty string (`''`). Since the stylesheet is completely empty and only contains the headers for the theme, loading it would be a waste of resources. Using an empty string allows us to inline styles using `wp_add_inline_style`, without actually enqueueing a file.
* This PR also removes non-`woff2` files. Since we no longer support IE11, these are not needed (also see #50)