### PR TITLE
Remove superfluous function_exists checks

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,42 +1,36 @@
 <?php
 
-if ( ! function_exists( 'twentytwentytwo_support' ) ) :
-	function twentytwentytwo_support()  {
+function twentytwentytwo_support()  {
 
-		// Adding support for featured images.
-		add_theme_support( 'post-thumbnails' );
+	// Adding support for featured images.
+	add_theme_support( 'post-thumbnails' );
 
-		// Adding support for core block visual styles.
-		add_theme_support( 'wp-block-styles' );
+	// Adding support for core block visual styles.
+	add_theme_support( 'wp-block-styles' );
 
-		// Adding support for responsive embedded content.
-		add_theme_support( 'responsive-embeds' );
-	}
-	add_action( 'after_setup_theme', 'twentytwentytwo_support' );
-endif;
+	// Adding support for responsive embedded content.
+	add_theme_support( 'responsive-embeds' );
+}
+add_action( 'after_setup_theme', 'twentytwentytwo_support' );
 
-if ( ! function_exists( 'twentytwentytwo_styles' ) ) :
-	/**
-	 * Enqueue scripts and styles.
-	 */
-	function twentytwentytwo_styles() {
-		// Enqueue theme stylesheet.
-		wp_enqueue_style( 'twentytwentytwo-style', get_template_directory_uri() . '/style.css', array(), wp_get_theme()->get( 'Version' ) );
-	}
-	add_action( 'wp_enqueue_scripts', 'twentytwentytwo_styles' );
-endif;
+/**
+ * Enqueue scripts and styles.
+ */
+function twentytwentytwo_styles() {
+	// Enqueue theme stylesheet.
+	wp_enqueue_style( 'twentytwentytwo-style', get_template_directory_uri() . '/style.css', array(), wp_get_theme()->get( 'Version' ) );
+}
+add_action( 'wp_enqueue_scripts', 'twentytwentytwo_styles' );
 
-if ( ! function_exists( 'twentytwentytwo_editor_styles' ) ) :
-	/**
-	 * Enqueue editor styles.
-	 */
-	function twentytwentytwo_editor_styles() {
-		// Enqueue editor styles.
-		add_editor_style(
-			array(
-				get_stylesheet_uri(),
-			)
-		);
-	}
-	add_action( 'admin_init', 'twentytwentytwo_editor_styles' );
-endif;
+/**
+ * Enqueue editor styles.
+ */
+function twentytwentytwo_editor_styles() {
+	// Enqueue editor styles.
+	add_editor_style(
+		array(
+			get_stylesheet_uri(),
+		)
+	);
+}
+add_action( 'admin_init', 'twentytwentytwo_editor_styles' );


### PR DESCRIPTION
There is no need to make the functions pluggable, since child themes can modify or remove them using `remove_action/add_action`.

For further background please see : https://github.com/WordPress/twentyseventeen/pull/419, https://github.com/Automattic/_s/issues/1116, https://github.com/Automattic/_s/pull/1277