### PR TITLE
Use "header" template part inside of the "header-large-dark" template part

### DIFF
--- a/block-template-parts/header-large-dark.html
+++ b/block-template-parts/header-large-dark.html
@@ -1,15 +1,5 @@
-<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignwide"><!-- wp:group {"layout":{"type":"flex"}} -->
-<div class="wp-block-group"><!-- wp:site-logo {"width":64} /-->
-
-<!-- wp:site-title /--></div>
-<!-- /wp:group -->
-
-<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
-<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-<!-- /wp:navigation --></div>
-<!-- /wp:group -->
+<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:template-part {"slug":"header","tagName":"header","layout":{"inherit":true},"align":"wide"} /-->
 
 <!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column -->


### PR DESCRIPTION
Fixes https://github.com/WordPress/twentytwentytwo/issues/54. 

This potential solution is thanks to a conversation I just had with @jasmussen. Rather than create a separate template part for the navigation block, we can actually just the the more generic `header.html` template part _within_ the `header-large-dark.html` template. 

When folks edit the navigation inside there, it'll update the original `header.html` template, and keep things in sync. 

The only issue I'm seeing is that the Site Title color doesn't appear to inherit the correct white link color (even though it's properly set on the container). I also tried setting it on the template part itself, but that doesn't seem to fix it either. Seems like a Gutenberg bug? 

Editor|Front end
---|---
<img width="1246" alt="Screen Shot 2021-10-07 at 12 53 46 PM" src="https://user-images.githubusercontent.com/1202812/136429831-20926ff9-4434-4593-97a5-473b102399f0.png">|<img width="1246" alt="Screen Shot 2021-10-07 at 12 53 57 PM" src="https://user-images.githubusercontent.com/1202812/136429830-94de4e12-d685-4ff0-8f22-665000999e42.png">

## To test:

1. Using the site editor, edit the navigation while viewing the `front-page` template. 
2. Save your changes.
3. Ensure that change is synced to the navigation on other templates as well. 