### PR TITLE
Add a WordPress credit block pattern and load it in the footer

### DIFF
--- a/block-template-parts/footer.html
+++ b/block-template-parts/footer.html
@@ -1,7 +1,7 @@
 <!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"max(1.25rem, 5vw)","top":"8rem","right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide" style="padding-top:8rem;padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:site-title {"level":0} /-->
 
-<!-- wp:paragraph {"align":"right"} -->
-<p class="has-text-align-right">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
-<!-- /wp:paragraph --></div>
+<!-- wp:pattern {"slug":"twentytwentytwo/wordpress-credit"} /-->
+
+</div>
 <!-- /wp:group -->

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -4,7 +4,6 @@
  *
  * @since 1.0
  */
-
 if ( ! function_exists( 'twentytwentytwo_register_block_patterns' ) ) :
 	function twentytwentytwo_register_block_patterns() {
 		if ( function_exists( 'register_block_pattern_category' ) ) {

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -19,6 +19,10 @@ if ( ! function_exists( 'twentytwentytwo_register_block_patterns' ) ) :
 				'twentytwentytwo-query',
 				array( 'label' => __( 'Twenty Twenty-Two Posts', 'twentytwentytwo' ) )
 			);
+			register_block_pattern_category(
+				'twentytwentytwo-i18n',
+				array( 'label' => __( 'Twenty Twenty-Two i18n', 'twentytwentytwo' ) )
+			);
 		}
 		if ( function_exists( 'register_block_pattern' ) ) {
 			$block_patterns = array(

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -57,6 +57,7 @@ if ( ! function_exists( 'twentytwentytwo_register_block_patterns' ) ) :
 				'query-image-grid',
 				'query-large-titles',
 				'query-irregular-grid',
+				'wordpress-credit',
 			);
 
 			foreach ( $block_patterns as $block_pattern ) {

--- a/inc/patterns/wordpress-credit.php
+++ b/inc/patterns/wordpress-credit.php
@@ -4,9 +4,9 @@
  *
  */
 return array(
-	'title'       => __( 'WordPress Credit', 'twentytwentytwo' ),
-	'categories'  => array( 'twentytwentytwo' ),
-	'content'     => '<!-- wp:paragraph {"align":"right"} -->
+	'title'      => __( 'WordPress Credit', 'twentytwentytwo' ),
+	'categories' => array( 'twentytwentytwo-i18n' ),
+	'content'    => '<!-- wp:paragraph {"align":"right"} -->
 <p class="has-text-align-right">' . __( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
-<!-- /wp:paragraph -->'
+<!-- /wp:paragraph -->',
 );

--- a/inc/patterns/wordpress-credit.php
+++ b/inc/patterns/wordpress-credit.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * WordPress Credit block pattern
+ *
+ */
+return array(
+	'title'       => __( 'WordPress Credit', 'twentytwentytwo' ),
+	'categories'  => array( 'twentytwentytwo' ),
+	'content'     => '<!-- wp:paragraph {"align":"right"} -->
+<p class="has-text-align-right">' . __( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
+<!-- /wp:paragraph -->'
+);


### PR DESCRIPTION
This PR is an attempt to solve #30. It depends on https://github.com/WordPress/gutenberg/pull/33217/

It adds a WordPress credit block pattern — which contains some text that can be translated — and includes it in the footer, instead of using the block markup directly.

**To test**
- Check out the above Gutenberg PR
- Verify the credit in the footer appears as expected in the site editor and front-end
- Verify you can add the pattern in the editor
- Verify you can edit it in the site editor

https://user-images.githubusercontent.com/5375500/136443900-684a0450-ec02-494a-ba70-d5d407d321ec.mp4


