### PR TITLE
Use relative path instead of root-absolute path for font src

### DIFF
--- a/style.css
+++ b/style.css
@@ -37,7 +37,7 @@ Twenty Twenty-Two is distributed under the terms of the GNU GPL.
 	font-weight: 200 900;
 	font-style: normal;
 	font-stretch: normal;
-	src: url('/wp-content/themes/twentytwentytwo/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');
+	src: url('assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');
 }
 
 @font-face{
@@ -45,5 +45,5 @@ Twenty Twenty-Two is distributed under the terms of the GNU GPL.
 	font-weight: 200 900;
 	font-style: italic;
 	font-stretch: normal;
-	src: url('/wp-content/themes/twentytwentytwo/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');
+	src: url('assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');
 }


### PR DESCRIPTION
This fixes the path to the font files on setups where `/wp-content` is not the `WP_CONTENT_DIR`. For example, for me I have `/content` so that actual path would need to be `/content/themes/twentytwentytwo/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2`. Making the path relative to the current directory fixes the issue.