### PR TITLE
Add header block patterns

### DIFF
--- a/block-template-parts/header.html
+++ b/block-template-parts/header.html
@@ -3,7 +3,7 @@
 <div class="wp-block-group">
 <!-- wp:site-logo {"width":64} /-->
 
-<!-- wp:site-title /--></div>
+<!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->

--- a/functions.php
+++ b/functions.php
@@ -70,3 +70,6 @@ if ( ! function_exists( 'twentytwentytwo_get_font_face_styles' ) ) :
 		";
 	}
 endif;
+
+// Block patterns
+require get_template_directory() . '/inc/block-patterns.php';

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -19,7 +19,7 @@ if ( ! function_exists( 'twentytwentytwo_register_block_patterns' ) ) :
 				'header-with-tagline',
 				'header-text-only',
 				'header-text-only-with-tagline',
-				'header-text-only-stacked-tagline'
+				'header-text-only-with-stacked-tagline'
 				'header-text-only-all-caps-with-tagline',
 				'header-logo-navigation',
 				'header-logo-navigation-social',

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -22,6 +22,7 @@ if ( ! function_exists( 'twentytwentytwo_register_block_patterns' ) ) :
 				'header-text-only-all-caps-with-tagline',
 				'header-logo-navigation',
 				'header-logo-navigation-social',
+				'header-title-navigation-social',
 				'header-logo-navigation-offset-tagline',
 				'header-stacked',
 				'header-large-dark'

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -26,7 +26,11 @@ if ( ! function_exists( 'twentytwentytwo_register_block_patterns' ) ) :
 				'header-title-navigation-social',
 				'header-logo-navigation-offset-tagline',
 				'header-stacked',
-				'header-large-dark'
+				'header-large-dark',
+				'header-centered-logo',
+				'header-centered-logo-in-navigation',
+				'header-centered-title-navigation-social',
+				'header-title-and-button'
 			);
 
 			foreach ( $block_patterns as $block_pattern ) {

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -30,7 +30,7 @@ if ( ! function_exists( 'twentytwentytwo_register_block_patterns' ) ) :
 				'header-centered-logo',
 				'header-centered-logo-in-navigation',
 				'header-centered-title-navigation-social',
-				'header-title-and-button'
+				'header-title-and-button',
 			);
 
 			foreach ( $block_patterns as $block_pattern ) {

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Twenty Twenty-Two: Block Patterns
+ *
+ * @since 1.0
+ */
+
+if ( ! function_exists( 'twentytwentytwo_register_block_patterns' ) ) :
+	function twentytwentytwo_register_block_patterns() {
+		if ( function_exists( 'register_block_pattern_category' ) ) {
+			register_block_pattern_category(
+				'twentytwentytwo-headers',
+				array( 'label' => __( 'Twenty Twenty-Two Headers', 'twentytwentytwo' ) )
+			);
+		}
+		if ( function_exists( 'register_block_pattern' ) ) {
+			$block_patterns = array(
+				'header-default',
+				'header-with-tagline',
+				'header-text-only',
+				'header-text-only-with-tagline',
+				'header-text-only-all-caps-with-tagline',
+				'header-logo-navigation',
+				'header-logo-navigation-social',
+				'header-logo-navigation-offset-tagline',
+				'header-stacked',
+				'header-large-dark'
+			);
+
+			foreach ( $block_patterns as $block_pattern ) {
+				register_block_pattern(
+					'twentytwentytwo/' . $block_pattern,
+					require __DIR__ . '/patterns/' . $block_pattern . '.php'
+				);
+			}
+		}
+	}
+endif;
+add_action( 'init', 'twentytwentytwo_register_block_patterns', 9 );

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -19,6 +19,7 @@ if ( ! function_exists( 'twentytwentytwo_register_block_patterns' ) ) :
 				'header-with-tagline',
 				'header-text-only',
 				'header-text-only-with-tagline',
+				'header-text-only-stacked-tagline'
 				'header-text-only-all-caps-with-tagline',
 				'header-logo-navigation',
 				'header-logo-navigation-social',

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -17,9 +17,9 @@ if ( ! function_exists( 'twentytwentytwo_register_block_patterns' ) ) :
 			$block_patterns = array(
 				'header-default',
 				'header-with-tagline',
+				'header-text-only-with-stacked-tagline',
 				'header-text-only',
 				'header-text-only-with-tagline',
-				'header-text-only-with-stacked-tagline'
 				'header-text-only-all-caps-with-tagline',
 				'header-logo-navigation',
 				'header-logo-navigation-social',

--- a/inc/patterns/header-centered-logo-in-navigation.php
+++ b/inc/patterns/header-centered-logo-in-navigation.php
@@ -6,13 +6,17 @@ return array(
 	'title'      => __( 'Header with centered Logo in Navigation', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"center"}} -->
+	'content'    => '<!-- wp:group {"tagName":"header","align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"center"}} -->
 					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
-					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+					<!-- wp:navigation-link {"isTopLevelLink":true} /-->
+
+					<!-- wp:navigation-link {"isTopLevelLink":true} /-->
 
 					<!-- wp:site-logo {"width":90} /-->
 
-					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+					<!-- wp:navigation-link {"isTopLevelLink":true} /-->
+
+					<!-- wp:navigation-link {"isTopLevelLink":true} /-->
 					<!-- /wp:navigation --></header>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-centered-logo-in-navigation.php
+++ b/inc/patterns/header-centered-logo-in-navigation.php
@@ -6,13 +6,13 @@ return array(
 	'title'      => __( 'Header with centered Logo in Navigation', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"center"}} -->
-					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
+	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"center"}} -->
+					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 
 					<!-- wp:site-logo {"width":90} /-->
 
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-					<!-- /wp:navigation --></div>
+					<!-- /wp:navigation --></header>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-centered-logo-in-navigation.php
+++ b/inc/patterns/header-centered-logo-in-navigation.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Header with centered Logo in Navigation', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"tagName":"header","align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"center"}} -->
-					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"center"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:navigation-link {"isTopLevelLink":true} /-->
 
 					<!-- wp:navigation-link {"isTopLevelLink":true} /-->
@@ -17,6 +17,6 @@ return array(
 					<!-- wp:navigation-link {"isTopLevelLink":true} /-->
 
 					<!-- wp:navigation-link {"isTopLevelLink":true} /-->
-					<!-- /wp:navigation --></header>
+					<!-- /wp:navigation --></div>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-centered-logo-in-navigation.php
+++ b/inc/patterns/header-centered-logo-in-navigation.php
@@ -3,10 +3,10 @@
  * Header with centered Logo in Navigation block pattern
  */
 return array(
-	'title'       => __( 'Header with centered Logo in Navigation', 'twentytwentytwo' ),
-	'categories'  => array( 'twentytwentytwo-headers' ),
+	'title'      => __( 'Header with centered Logo in Navigation', 'twentytwentytwo' ),
+	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"center"}} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"center"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 
@@ -14,5 +14,5 @@ return array(
 
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 					<!-- /wp:navigation --></div>
-					<!-- /wp:group -->'
+					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-centered-logo-in-navigation.php
+++ b/inc/patterns/header-centered-logo-in-navigation.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Header with centered Logo in Navigation block pattern
+ */
+return array(
+	'title'       => __( 'Header with centered Logo in Navigation', 'twentytwentytwo' ),
+	'categories'  => array( 'twentytwentytwo-headers' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"center"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
+					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+
+					<!-- wp:site-logo {"width":90} /-->
+
+					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+					<!-- /wp:navigation --></div>
+					<!-- /wp:group -->'
+);

--- a/inc/patterns/header-centered-logo.php
+++ b/inc/patterns/header-centered-logo.php
@@ -3,10 +3,10 @@
  * Header with centered Logo block pattern
  */
 return array(
-	'title'       => __( 'Header with centered Logo', 'twentytwentytwo' ),
-	'categories'  => array( 'twentytwentytwo-headers' ),
+	'title'      => __( 'Header with centered Logo', 'twentytwentytwo' ),
+	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:columns {"verticalAlignment":"center"} -->
 					<div class="wp-block-columns are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center"} -->
 					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"400","textTransform":"uppercase"}}} /--></div>
@@ -22,5 +22,5 @@ return array(
 					<!-- /wp:navigation --></div>
 					<!-- /wp:column --></div>
 					<!-- /wp:columns --></div>
-					<!-- /wp:group -->'
+					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-centered-logo.php
+++ b/inc/patterns/header-centered-logo.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Header with centered Logo block pattern
+ */
+return array(
+	'title'       => __( 'Header with centered Logo', 'twentytwentytwo' ),
+	'categories'  => array( 'twentytwentytwo-headers' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:columns {"verticalAlignment":"center"} -->
+					<div class="wp-block-columns are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center"} -->
+					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"400","textTransform":"uppercase"}}} /--></div>
+					<!-- /wp:column -->
+
+					<!-- wp:column {"width":"64px"} -->
+					<div class="wp-block-column" style="flex-basis:64px"><!-- wp:site-logo {"width":64} /--></div>
+					<!-- /wp:column -->
+
+					<!-- wp:column {"verticalAlignment":"center"} -->
+					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
+					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+					<!-- /wp:navigation --></div>
+					<!-- /wp:column --></div>
+					<!-- /wp:columns --></div>
+					<!-- /wp:group -->'
+);

--- a/inc/patterns/header-centered-logo.php
+++ b/inc/patterns/header-centered-logo.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Header with centered Logo', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
-					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:columns {"verticalAlignment":"center"} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:columns {"verticalAlignment":"center"} -->
 					<div class="wp-block-columns are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center"} -->
 					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"400","textTransform":"uppercase"}}} /--></div>
 					<!-- /wp:column -->
@@ -21,6 +21,6 @@ return array(
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 					<!-- /wp:navigation --></div>
 					<!-- /wp:column --></div>
-					<!-- /wp:columns --></header>
+					<!-- /wp:columns --></div>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-centered-logo.php
+++ b/inc/patterns/header-centered-logo.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Header with centered Logo', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
-					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:columns {"verticalAlignment":"center"} -->
+	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
+					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:columns {"verticalAlignment":"center"} -->
 					<div class="wp-block-columns are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center"} -->
 					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"400","textTransform":"uppercase"}}} /--></div>
 					<!-- /wp:column -->
@@ -21,6 +21,6 @@ return array(
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 					<!-- /wp:navigation --></div>
 					<!-- /wp:column --></div>
-					<!-- /wp:columns --></div>
+					<!-- /wp:columns --></header>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-centered-title-navigation-social.php
+++ b/inc/patterns/header-centered-title-navigation-social.php
@@ -3,10 +3,10 @@
  * Centered title with Navigation and Social Links Header block pattern
  */
 return array(
-	'title'       => __( 'Centered title with Navigation and Social Links Header', 'twentytwentytwo' ),
-	'categories'  => array( 'twentytwentytwo-headers' ),
+	'title'      => __( 'Centered title with Navigation and Social Links Header', 'twentytwentytwo' ),
+	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:columns {"verticalAlignment":"center"} -->
 					<div class="wp-block-columns are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center"} -->
 					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:navigation {"itemsJustification":"left","isResponsive":true} -->
@@ -26,5 +26,5 @@ return array(
 					<!-- /wp:social-links --></div>
 					<!-- /wp:column --></div>
 					<!-- /wp:columns --></div>
-					<!-- /wp:group -->'
+					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-centered-title-navigation-social.php
+++ b/inc/patterns/header-centered-title-navigation-social.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Centered title with Navigation and Social Links Header block pattern
+ */
+return array(
+	'title'       => __( 'Centered title with Navigation and Social Links Header', 'twentytwentytwo' ),
+	'categories'  => array( 'twentytwentytwo-headers' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:columns {"verticalAlignment":"center"} -->
+					<div class="wp-block-columns are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center"} -->
+					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:navigation {"itemsJustification":"left","isResponsive":true} -->
+					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+					<!-- /wp:navigation --></div>
+					<!-- /wp:column -->
+
+					<!-- wp:column {"width":""} -->
+					<div class="wp-block-column"><!-- wp:site-title {"textAlign":"center","style":{"typography":{"textTransform":"uppercase","fontStyle":"normal","fontWeight":"700"}}} /--></div>
+					<!-- /wp:column -->
+
+					<!-- wp:column {"verticalAlignment":"center"} -->
+					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:social-links {"iconColor":"foreground","iconColorValue":"var(--wp--preset--color--foreground)","className":"is-style-logos-only","layout":{"type":"flex","justifyContent":"right"}} -->
+					<ul class="wp-block-social-links has-icon-color is-style-logos-only"><!-- wp:social-link {"url":"#","service":"twitter"} /-->
+
+					<!-- wp:social-link {"url":"#","service":"instagram"} /--></ul>
+					<!-- /wp:social-links --></div>
+					<!-- /wp:column --></div>
+					<!-- /wp:columns --></div>
+					<!-- /wp:group -->'
+);

--- a/inc/patterns/header-centered-title-navigation-social.php
+++ b/inc/patterns/header-centered-title-navigation-social.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Centered title with Navigation and Social Links Header', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
-					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:columns {"verticalAlignment":"center"} -->
+	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
+					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:columns {"verticalAlignment":"center"} -->
 					<div class="wp-block-columns are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center"} -->
 					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:navigation {"itemsJustification":"left","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
@@ -25,6 +25,6 @@ return array(
 					<!-- wp:social-link {"url":"#","service":"instagram"} /--></ul>
 					<!-- /wp:social-links --></div>
 					<!-- /wp:column --></div>
-					<!-- /wp:columns --></div>
+					<!-- /wp:columns --></header>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-centered-title-navigation-social.php
+++ b/inc/patterns/header-centered-title-navigation-social.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Centered title with Navigation and Social Links Header', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
-					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:columns {"verticalAlignment":"center"} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:columns {"verticalAlignment":"center"} -->
 					<div class="wp-block-columns are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center"} -->
 					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:navigation {"itemsJustification":"left","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
@@ -25,6 +25,6 @@ return array(
 					<!-- wp:social-link {"url":"#","service":"instagram"} /--></ul>
 					<!-- /wp:social-links --></div>
 					<!-- /wp:column --></div>
-					<!-- /wp:columns --></header>
+					<!-- /wp:columns --></div>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-default.php
+++ b/inc/patterns/header-default.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Default Header block pattern
+ */
+return array(
+	'title'       => __( 'Default Header', 'twentytwentytwo' ),
+	'categories'  => array( 'twentytwentytwo-headers' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
+					<div class="wp-block-group">
+					<!-- wp:site-logo {"width":64} /-->
+
+					<!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /--></div>
+					<!-- /wp:group -->
+
+					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
+					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+					<!-- /wp:navigation --></div>
+					<!-- /wp:group -->'
+);

--- a/inc/patterns/header-default.php
+++ b/inc/patterns/header-default.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Default Header', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
+	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
 					<div class="wp-block-group">
 					<!-- wp:site-logo {"width":64} /-->
 
@@ -16,6 +16,6 @@ return array(
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-					<!-- /wp:navigation --></div>
+					<!-- /wp:navigation --></header>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-default.php
+++ b/inc/patterns/header-default.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Default Header', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
 					<div class="wp-block-group">
 					<!-- wp:site-logo {"width":64} /-->
 
@@ -16,6 +16,6 @@ return array(
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-					<!-- /wp:navigation --></header>
+					<!-- /wp:navigation --></div>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-default.php
+++ b/inc/patterns/header-default.php
@@ -3,10 +3,10 @@
  * Default Header block pattern
  */
 return array(
-	'title'       => __( 'Default Header', 'twentytwentytwo' ),
-	'categories'  => array( 'twentytwentytwo-headers' ),
+	'title'      => __( 'Default Header', 'twentytwentytwo' ),
+	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
 					<div class="wp-block-group">
 					<!-- wp:site-logo {"width":64} /-->
@@ -17,5 +17,5 @@ return array(
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 					<!-- /wp:navigation --></div>
-					<!-- /wp:group -->'
+					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-large-dark.php
+++ b/inc/patterns/header-large-dark.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Large Header', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"tagName":"header","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
-					<header class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	'content'    => '<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+					<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
 					<div class="wp-block-group">
 					<!-- wp:site-logo {"width":64} /-->
@@ -24,6 +24,6 @@ return array(
 					<div class="wp-block-columns alignwide"><!-- wp:column -->
 					<div class="wp-block-column"><!-- wp:site-tagline {"style":{"typography":{"fontFamily":"var:preset|font-family|source-serif-pro","fontWeight":"300","fontSize":"clamp(4rem, 8vw, 6.25rem)","lineHeight":"1.15"}}} /--></div>
 					<!-- /wp:column --></div>
-					<!-- /wp:columns --></header>
+					<!-- /wp:columns --></div>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-large-dark.php
+++ b/inc/patterns/header-large-dark.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Large Header block pattern
+ */
+return array(
+	'title'       => __( 'Large Header', 'twentytwentytwo' ),
+	'categories'  => array( 'twentytwentytwo-headers' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'content'     => '<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+					<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
+					<div class="wp-block-group">
+					<!-- wp:site-logo {"width":64} /-->
+
+					<!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /--></div>
+					<!-- /wp:group -->
+
+					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
+					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+					<!-- /wp:navigation --></div>
+					<!-- /wp:group -->
+
+					<!-- wp:columns {"align":"wide"} -->
+					<div class="wp-block-columns alignwide"><!-- wp:column -->
+					<div class="wp-block-column"><!-- wp:site-tagline {"style":{"typography":{"fontFamily":"var:preset|font-family|source-serif-pro","fontWeight":"300","fontSize":"clamp(4rem, 8vw, 6.25rem)","lineHeight":"1.15"}}} /--></div>
+					<!-- /wp:column --></div>
+					<!-- /wp:columns --></div>
+					<!-- /wp:group -->'
+);

--- a/inc/patterns/header-large-dark.php
+++ b/inc/patterns/header-large-dark.php
@@ -3,10 +3,10 @@
  * Large Header block pattern
  */
 return array(
-	'title'       => __( 'Large Header', 'twentytwentytwo' ),
-	'categories'  => array( 'twentytwentytwo-headers' ),
+	'title'      => __( 'Large Header', 'twentytwentytwo' ),
+	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'     => '<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+	'content'    => '<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
 					<div class="wp-block-group">
@@ -25,5 +25,5 @@ return array(
 					<div class="wp-block-column"><!-- wp:site-tagline {"style":{"typography":{"fontFamily":"var:preset|font-family|source-serif-pro","fontWeight":"300","fontSize":"clamp(4rem, 8vw, 6.25rem)","lineHeight":"1.15"}}} /--></div>
 					<!-- /wp:column --></div>
 					<!-- /wp:columns --></div>
-					<!-- /wp:group -->'
+					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-large-dark.php
+++ b/inc/patterns/header-large-dark.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Large Header', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
-					<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	'content'    => '<!-- wp:group {"tagName":"header","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+					<header class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
 					<div class="wp-block-group">
 					<!-- wp:site-logo {"width":64} /-->
@@ -24,6 +24,6 @@ return array(
 					<div class="wp-block-columns alignwide"><!-- wp:column -->
 					<div class="wp-block-column"><!-- wp:site-tagline {"style":{"typography":{"fontFamily":"var:preset|font-family|source-serif-pro","fontWeight":"300","fontSize":"clamp(4rem, 8vw, 6.25rem)","lineHeight":"1.15"}}} /--></div>
 					<!-- /wp:column --></div>
-					<!-- /wp:columns --></div>
+					<!-- /wp:columns --></header>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-logo-navigation-offset-tagline.php
+++ b/inc/patterns/header-logo-navigation-offset-tagline.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Logo, Navigation, and offset Tagline Header block pattern
+ */
+return array(
+	'title'       => __( 'Logo, Navigation, and offset Tagline Header', 'twentytwentytwo' ),
+	'categories'  => array( 'twentytwentytwo-headers' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem"}}}} -->
+					<div class="wp-block-group alignwide" style="padding-bottom:8rem"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw)"><!-- wp:site-logo {"width":64} /-->
+
+					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
+					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+					<!-- /wp:navigation --></div>
+					<!-- /wp:group -->
+
+					<!-- wp:columns {"isStackedOnMobile":false,"align":"wide"} -->
+					<div class="wp-block-columns alignwide is-not-stacked-on-mobile"><!-- wp:column {"width":"64px"} -->
+					<div class="wp-block-column" style="flex-basis:64px"></div>
+					<!-- /wp:column -->
+
+					<!-- wp:column {"width":"380px"} -->
+					<div class="wp-block-column" style="flex-basis:380px"><!-- wp:site-tagline {"fontSize":"small"} /--></div>
+					<!-- /wp:column --></div>
+					<!-- /wp:columns -->
+
+					<!-- wp:paragraph -->
+					<p></p>
+					<!-- /wp:paragraph --></div>
+					<!-- /wp:group -->'
+);

--- a/inc/patterns/header-logo-navigation-offset-tagline.php
+++ b/inc/patterns/header-logo-navigation-offset-tagline.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Logo, Navigation, and offset Tagline Header', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem"}}}} -->
-					<header class="wp-block-group alignwide" style="padding-bottom:8rem"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem"}}}} -->
+					<div class="wp-block-group alignwide" style="padding-bottom:8rem"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw)"><!-- wp:site-logo {"width":64} /-->
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
@@ -23,6 +23,6 @@ return array(
 					<!-- wp:column {"width":"380px"} -->
 					<div class="wp-block-column" style="flex-basis:380px"><!-- wp:site-tagline {"fontSize":"small"} /--></div>
 					<!-- /wp:column --></div>
-					<!-- /wp:columns --></header>
+					<!-- /wp:columns --></div>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-logo-navigation-offset-tagline.php
+++ b/inc/patterns/header-logo-navigation-offset-tagline.php
@@ -3,10 +3,10 @@
  * Logo, Navigation, and offset Tagline Header block pattern
  */
 return array(
-	'title'       => __( 'Logo, Navigation, and offset Tagline Header', 'twentytwentytwo' ),
-	'categories'  => array( 'twentytwentytwo-headers' ),
+	'title'      => __( 'Logo, Navigation, and offset Tagline Header', 'twentytwentytwo' ),
+	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem"}}}} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem"}}}} -->
 					<div class="wp-block-group alignwide" style="padding-bottom:8rem"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw)"><!-- wp:site-logo {"width":64} /-->
 
@@ -24,5 +24,5 @@ return array(
 					<div class="wp-block-column" style="flex-basis:380px"><!-- wp:site-tagline {"fontSize":"small"} /--></div>
 					<!-- /wp:column --></div>
 					<!-- /wp:columns --></div>
-					<!-- /wp:group -->'
+					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-logo-navigation-offset-tagline.php
+++ b/inc/patterns/header-logo-navigation-offset-tagline.php
@@ -23,10 +23,6 @@ return array(
 					<!-- wp:column {"width":"380px"} -->
 					<div class="wp-block-column" style="flex-basis:380px"><!-- wp:site-tagline {"fontSize":"small"} /--></div>
 					<!-- /wp:column --></div>
-					<!-- /wp:columns -->
-
-					<!-- wp:paragraph -->
-					<p></p>
-					<!-- /wp:paragraph --></div>
+					<!-- /wp:columns --></div>
 					<!-- /wp:group -->'
 );

--- a/inc/patterns/header-logo-navigation-offset-tagline.php
+++ b/inc/patterns/header-logo-navigation-offset-tagline.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Logo, Navigation, and offset Tagline Header', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem"}}}} -->
-					<div class="wp-block-group alignwide" style="padding-bottom:8rem"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem"}}}} -->
+					<header class="wp-block-group alignwide" style="padding-bottom:8rem"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw)"><!-- wp:site-logo {"width":64} /-->
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
@@ -23,6 +23,6 @@ return array(
 					<!-- wp:column {"width":"380px"} -->
 					<div class="wp-block-column" style="flex-basis:380px"><!-- wp:site-tagline {"fontSize":"small"} /--></div>
 					<!-- /wp:column --></div>
-					<!-- /wp:columns --></div>
+					<!-- /wp:columns --></header>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-logo-navigation-social.php
+++ b/inc/patterns/header-logo-navigation-social.php
@@ -3,10 +3,10 @@
  * Logo, Navigation, and Social Links Header block pattern
  */
 return array(
-	'title'       => __( 'Logo, Navigation, and Social Links Header', 'twentytwentytwo' ),
-	'categories'  => array( 'twentytwentytwo-headers' ),
+	'title'      => __( 'Logo, Navigation, and Social Links Header', 'twentytwentytwo' ),
+	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-logo {"width":64} /-->
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
@@ -18,5 +18,5 @@ return array(
 					<!-- wp:social-link {"url":"#","service":"twitter"} /--></ul>
 					<!-- /wp:social-links -->
 					<!-- /wp:navigation --></div>
-					<!-- /wp:group -->'
+					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-logo-navigation-social.php
+++ b/inc/patterns/header-logo-navigation-social.php
@@ -12,7 +12,7 @@ return array(
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 
-					<!-- wp:social-links {"iconColor":"foreground","iconColorValue":"#000000","className":"is-style-logos-only"} -->
+					<!-- wp:social-links {"iconColor":"foreground","iconColorValue":"var(--wp--preset--color--foreground)","className":"is-style-logos-only"} -->
 					<ul class="wp-block-social-links has-icon-color is-style-logos-only"><!-- wp:social-link {"url":"#","service":"instagram"} /-->
 
 					<!-- wp:social-link {"url":"#","service":"twitter"} /--></ul>

--- a/inc/patterns/header-logo-navigation-social.php
+++ b/inc/patterns/header-logo-navigation-social.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Logo, Navigation, and Social Links Header', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-logo {"width":64} /-->
+	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-logo {"width":64} /-->
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
@@ -17,6 +17,6 @@ return array(
 
 					<!-- wp:social-link {"url":"#","service":"twitter"} /--></ul>
 					<!-- /wp:social-links -->
-					<!-- /wp:navigation --></div>
+					<!-- /wp:navigation --></header>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-logo-navigation-social.php
+++ b/inc/patterns/header-logo-navigation-social.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Logo, Navigation, and Social Links Header block pattern
+ */
+return array(
+	'title'       => __( 'Logo, Navigation, and Social Links Header', 'twentytwentytwo' ),
+	'categories'  => array( 'twentytwentytwo-headers' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-logo {"width":64} /-->
+
+					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
+					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+
+					<!-- wp:social-links {"iconColor":"foreground","iconColorValue":"#000000","className":"is-style-logos-only"} -->
+					<ul class="wp-block-social-links has-icon-color is-style-logos-only"><!-- wp:social-link {"url":"#","service":"instagram"} /-->
+
+					<!-- wp:social-link {"url":"#","service":"twitter"} /--></ul>
+					<!-- /wp:social-links -->
+					<!-- /wp:navigation --></div>
+					<!-- /wp:group -->'
+);

--- a/inc/patterns/header-logo-navigation-social.php
+++ b/inc/patterns/header-logo-navigation-social.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Logo, Navigation, and Social Links Header', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-logo {"width":64} /-->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-logo {"width":64} /-->
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
@@ -17,6 +17,6 @@ return array(
 
 					<!-- wp:social-link {"url":"#","service":"twitter"} /--></ul>
 					<!-- /wp:social-links -->
-					<!-- /wp:navigation --></header>
+					<!-- /wp:navigation --></div>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-logo-navigation.php
+++ b/inc/patterns/header-logo-navigation.php
@@ -6,11 +6,11 @@ return array(
 	'title'      => __( 'Logo and Navigation Header', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-logo {"width":64} /-->
+	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-logo {"width":64} /-->
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-					<!-- /wp:navigation --></div>
+					<!-- /wp:navigation --></header>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-logo-navigation.php
+++ b/inc/patterns/header-logo-navigation.php
@@ -3,14 +3,14 @@
  * Logo and Navigation Header
  */
 return array(
-	'title'       => __( 'Logo and Navigation Header', 'twentytwentytwo' ),
-	'categories'  => array( 'twentytwentytwo-headers' ),
+	'title'      => __( 'Logo and Navigation Header', 'twentytwentytwo' ),
+	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-logo {"width":64} /-->
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 					<!-- /wp:navigation --></div>
-					<!-- /wp:group -->'
+					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-logo-navigation.php
+++ b/inc/patterns/header-logo-navigation.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Logo and Navigation Header
+ */
+return array(
+	'title'       => __( 'Logo and Navigation Header', 'twentytwentytwo' ),
+	'categories'  => array( 'twentytwentytwo-headers' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-logo {"width":64} /-->
+
+					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
+					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+					<!-- /wp:navigation --></div>
+					<!-- /wp:group -->'
+);

--- a/inc/patterns/header-logo-navigation.php
+++ b/inc/patterns/header-logo-navigation.php
@@ -6,11 +6,11 @@ return array(
 	'title'      => __( 'Logo and Navigation Header', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-logo {"width":64} /-->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-logo {"width":64} /-->
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-					<!-- /wp:navigation --></header>
+					<!-- /wp:navigation --></div>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-stacked.php
+++ b/inc/patterns/header-stacked.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Logo and Navigation Header block pattern
+ */
+return array(
+	'title'       => __( 'Logo and Navigation Header', 'twentytwentytwo' ),
+	'categories'  => array( 'twentytwentytwo-headers' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-logo {"align":"center","width":128} /-->
+
+					<!-- wp:spacer {"height":10} -->
+					<div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
+					<!-- /wp:spacer -->
+
+					<!-- wp:site-title {"textAlign":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"400","textTransform":"uppercase"}}} /-->
+
+					<!-- wp:spacer {"height":10} -->
+					<div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
+					<!-- /wp:spacer -->
+
+					<!-- wp:navigation {"itemsJustification":"center","isResponsive":true} -->
+					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+					<!-- /wp:navigation --></div>
+					<!-- /wp:group -->'
+);

--- a/inc/patterns/header-stacked.php
+++ b/inc/patterns/header-stacked.php
@@ -3,10 +3,10 @@
  * Logo and Navigation Header block pattern
  */
 return array(
-	'title'       => __( 'Logo and Navigation Header', 'twentytwentytwo' ),
-	'categories'  => array( 'twentytwentytwo-headers' ),
+	'title'      => __( 'Logo and Navigation Header', 'twentytwentytwo' ),
+	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-logo {"align":"center","width":128} /-->
 
 					<!-- wp:spacer {"height":10} -->
@@ -22,5 +22,5 @@ return array(
 					<!-- wp:navigation {"itemsJustification":"center","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 					<!-- /wp:navigation --></div>
-					<!-- /wp:group -->'
+					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-stacked.php
+++ b/inc/patterns/header-stacked.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Logo and Navigation Header', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
-					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-logo {"align":"center","width":128} /-->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-logo {"align":"center","width":128} /-->
 
 					<!-- wp:spacer {"height":10} -->
 					<div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
@@ -21,6 +21,6 @@ return array(
 
 					<!-- wp:navigation {"itemsJustification":"center","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-					<!-- /wp:navigation --></header>
+					<!-- /wp:navigation --></div>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-stacked.php
+++ b/inc/patterns/header-stacked.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Logo and Navigation Header', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
-					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-logo {"align":"center","width":128} /-->
+	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
+					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-logo {"align":"center","width":128} /-->
 
 					<!-- wp:spacer {"height":10} -->
 					<div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
@@ -21,6 +21,6 @@ return array(
 
 					<!-- wp:navigation {"itemsJustification":"center","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-					<!-- /wp:navigation --></div>
+					<!-- /wp:navigation --></header>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-text-only-all-caps-with-tagline.php
+++ b/inc/patterns/header-text-only-all-caps-with-tagline.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Text-only Header with Tagline and all-caps Title', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex","justifyContent":"left"}} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex","justifyContent":"left"}} -->
 					<div class="wp-block-group"><!-- wp:site-title {"style":{"typography":{"textTransform":"uppercase"}}} /-->
 
 					<!-- wp:site-tagline {"fontSize":"small","style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /--></div>
@@ -15,6 +15,6 @@ return array(
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-					<!-- /wp:navigation --></header>
+					<!-- /wp:navigation --></div>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-text-only-all-caps-with-tagline.php
+++ b/inc/patterns/header-text-only-all-caps-with-tagline.php
@@ -3,10 +3,10 @@
  * Text-only Header with Tagline and all-caps Title block pattern
  */
 return array(
-	'title'       => __( 'Text-only Header with Tagline and all-caps Title', 'twentytwentytwo' ),
-	'categories'  => array( 'twentytwentytwo-headers' ),
+	'title'      => __( 'Text-only Header with Tagline and all-caps Title', 'twentytwentytwo' ),
+	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex","justifyContent":"left"}} -->
 					<div class="wp-block-group"><!-- wp:site-title {"style":{"typography":{"textTransform":"uppercase"}}} /-->
 
@@ -16,5 +16,5 @@ return array(
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 					<!-- /wp:navigation --></div>
-					<!-- /wp:group -->'
+					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-text-only-all-caps-with-tagline.php
+++ b/inc/patterns/header-text-only-all-caps-with-tagline.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Text-only Header with Tagline and all-caps Title', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex","justifyContent":"left"}} -->
+	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex","justifyContent":"left"}} -->
 					<div class="wp-block-group"><!-- wp:site-title {"style":{"typography":{"textTransform":"uppercase"}}} /-->
 
 					<!-- wp:site-tagline {"fontSize":"small","style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /--></div>
@@ -15,6 +15,6 @@ return array(
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-					<!-- /wp:navigation --></div>
+					<!-- /wp:navigation --></header>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-text-only-all-caps-with-tagline.php
+++ b/inc/patterns/header-text-only-all-caps-with-tagline.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Text-only Header with Tagline and all-caps Title block pattern
+ */
+return array(
+	'title'       => __( 'Text-only Header with Tagline and all-caps Title', 'twentytwentytwo' ),
+	'categories'  => array( 'twentytwentytwo-headers' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex","justifyContent":"left"}} -->
+					<div class="wp-block-group"><!-- wp:site-title {"style":{"typography":{"textTransform":"uppercase"}}} /-->
+
+					<!-- wp:site-tagline {"fontSize":"small","style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /--></div>
+					<!-- /wp:group -->
+
+					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
+					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+					<!-- /wp:navigation --></div>
+					<!-- /wp:group -->'
+);

--- a/inc/patterns/header-text-only-with-stacked-tagline.php
+++ b/inc/patterns/header-text-only-with-stacked-tagline.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Text-only Header with stacked Tagline block pattern
+ */
+return array(
+	'title'       => __( 'Text-only Header with stacked Tagline', 'twentytwentytwo' ),
+	'categories'  => array( 'twentytwentytwo-headers' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group -->
+					<div class="wp-block-group"><!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->
+
+					<!-- wp:site-tagline {"fontSize":"small","style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /--></div>
+					<!-- /wp:group -->
+
+					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
+					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+					<!-- /wp:navigation --></div>
+					<!-- /wp:group -->'
+);

--- a/inc/patterns/header-text-only-with-stacked-tagline.php
+++ b/inc/patterns/header-text-only-with-stacked-tagline.php
@@ -3,10 +3,10 @@
  * Text-only Header with stacked Tagline block pattern
  */
 return array(
-	'title'       => __( 'Text-only Header with stacked Tagline', 'twentytwentytwo' ),
-	'categories'  => array( 'twentytwentytwo-headers' ),
+	'title'      => __( 'Text-only Header with stacked Tagline', 'twentytwentytwo' ),
+	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group -->
 					<div class="wp-block-group"><!-- wp:site-title {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}},"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->
 
@@ -16,5 +16,5 @@ return array(
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 					<!-- /wp:navigation --></div>
-					<!-- /wp:group -->'
+					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-text-only-with-stacked-tagline.php
+++ b/inc/patterns/header-text-only-with-stacked-tagline.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Text-only Header with stacked Tagline', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group -->
+	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group -->
 					<div class="wp-block-group"><!-- wp:site-title {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}},"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->
 
 					<!-- wp:site-tagline {"style":{"spacing":{"margin":{"top":"0.25em","bottom":"0px"}},"typography":{"fontStyle":"italic","fontWeight":"400"}},"fontSize":"small"} /--></div>
@@ -15,6 +15,6 @@ return array(
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-					<!-- /wp:navigation --></div>
+					<!-- /wp:navigation --></header>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-text-only-with-stacked-tagline.php
+++ b/inc/patterns/header-text-only-with-stacked-tagline.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Text-only Header with stacked Tagline', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group -->
 					<div class="wp-block-group"><!-- wp:site-title {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}},"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->
 
 					<!-- wp:site-tagline {"style":{"spacing":{"margin":{"top":"0.25em","bottom":"0px"}},"typography":{"fontStyle":"italic","fontWeight":"400"}},"fontSize":"small"} /--></div>
@@ -15,6 +15,6 @@ return array(
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-					<!-- /wp:navigation --></header>
+					<!-- /wp:navigation --></div>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-text-only-with-stacked-tagline.php
+++ b/inc/patterns/header-text-only-with-stacked-tagline.php
@@ -8,9 +8,9 @@ return array(
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group -->
-					<div class="wp-block-group"><!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->
+					<div class="wp-block-group"><!-- wp:site-title {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}},"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->
 
-					<!-- wp:site-tagline {"fontSize":"small","style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /--></div>
+					<!-- wp:site-tagline {"style":{"spacing":{"margin":{"top":"0.25em","bottom":"0px"}},"typography":{"fontStyle":"italic","fontWeight":"400"}},"fontSize":"small"} /--></div>
 					<!-- /wp:group -->
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->

--- a/inc/patterns/header-text-only-with-tagline.php
+++ b/inc/patterns/header-text-only-with-tagline.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Text-only Header with Tagline', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex","justifyContent":"left"}} -->
+	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex","justifyContent":"left"}} -->
 					<div class="wp-block-group"><!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->
 
 					<!-- wp:site-tagline {"fontSize":"small","style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /--></div>
@@ -15,6 +15,6 @@ return array(
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-					<!-- /wp:navigation --></div>
+					<!-- /wp:navigation --></header>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-text-only-with-tagline.php
+++ b/inc/patterns/header-text-only-with-tagline.php
@@ -3,10 +3,10 @@
  * Text-only Header with Tagline block pattern
  */
 return array(
-	'title'       => __( 'Text-only Header with Tagline', 'twentytwentytwo' ),
-	'categories'  => array( 'twentytwentytwo-headers' ),
+	'title'      => __( 'Text-only Header with Tagline', 'twentytwentytwo' ),
+	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex","justifyContent":"left"}} -->
 					<div class="wp-block-group"><!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->
 
@@ -16,5 +16,5 @@ return array(
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 					<!-- /wp:navigation --></div>
-					<!-- /wp:group -->'
+					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-text-only-with-tagline.php
+++ b/inc/patterns/header-text-only-with-tagline.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Text-only Header with Tagline', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex","justifyContent":"left"}} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex","justifyContent":"left"}} -->
 					<div class="wp-block-group"><!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->
 
 					<!-- wp:site-tagline {"fontSize":"small","style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /--></div>
@@ -15,6 +15,6 @@ return array(
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-					<!-- /wp:navigation --></header>
+					<!-- /wp:navigation --></div>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-text-only-with-tagline.php
+++ b/inc/patterns/header-text-only-with-tagline.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Text-only Header with Tagline block pattern
+ */
+return array(
+	'title'       => __( 'Text-only Header with Tagline', 'twentytwentytwo' ),
+	'categories'  => array( 'twentytwentytwo-headers' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex","justifyContent":"left"}} -->
+					<div class="wp-block-group"><!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->
+
+					<!-- wp:site-tagline {"fontSize":"small","style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /--></div>
+					<!-- /wp:group -->
+
+					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
+					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+					<!-- /wp:navigation --></div>
+					<!-- /wp:group -->'
+);

--- a/inc/patterns/header-text-only.php
+++ b/inc/patterns/header-text-only.php
@@ -6,11 +6,11 @@ return array(
 	'title'      => __( 'Text-only Header', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /-->
+	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /-->
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-					<!-- /wp:navigation --></div>
+					<!-- /wp:navigation --></header>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-text-only.php
+++ b/inc/patterns/header-text-only.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Text-only Header block pattern
+ */
+return array(
+	'title'       => __( 'Text-only Header', 'twentytwentytwo' ),
+	'categories'  => array( 'twentytwentytwo-headers' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /-->
+
+					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
+					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+					<!-- /wp:navigation --></div>
+					<!-- /wp:group -->'
+);

--- a/inc/patterns/header-text-only.php
+++ b/inc/patterns/header-text-only.php
@@ -3,14 +3,14 @@
  * Text-only Header block pattern
  */
 return array(
-	'title'       => __( 'Text-only Header', 'twentytwentytwo' ),
-	'categories'  => array( 'twentytwentytwo-headers' ),
+	'title'      => __( 'Text-only Header', 'twentytwentytwo' ),
+	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /-->
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 					<!-- /wp:navigation --></div>
-					<!-- /wp:group -->'
+					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-text-only.php
+++ b/inc/patterns/header-text-only.php
@@ -6,11 +6,11 @@ return array(
 	'title'      => __( 'Text-only Header', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /-->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /-->
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-					<!-- /wp:navigation --></header>
+					<!-- /wp:navigation --></div>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-title-and-button.php
+++ b/inc/patterns/header-title-and-button.php
@@ -3,14 +3,14 @@
  * Title and Button Header block pattern
  */
 return array(
-	'title'       => __( 'Title and Button Header', 'twentytwentytwo' ),
-	'categories'  => array( 'twentytwentytwo-headers' ),
+	'title'      => __( 'Title and Button Header', 'twentytwentytwo' ),
+	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}},"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 					<!-- /wp:navigation --></div>
-					<!-- /wp:group -->'
+					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-title-and-button.php
+++ b/inc/patterns/header-title-and-button.php
@@ -6,11 +6,11 @@ return array(
 	'title'      => __( 'Title and Button Header', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}},"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->
+	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}},"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-					<!-- /wp:navigation --></div>
+					<!-- /wp:navigation --></header>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-title-and-button.php
+++ b/inc/patterns/header-title-and-button.php
@@ -6,11 +6,11 @@ return array(
 	'title'      => __( 'Title and Button Header', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}},"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}},"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-					<!-- /wp:navigation --></header>
+					<!-- /wp:navigation --></div>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-title-and-button.php
+++ b/inc/patterns/header-title-and-button.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Title and Button Header block pattern
+ */
+return array(
+	'title'       => __( 'Title and Button Header', 'twentytwentytwo' ),
+	'categories'  => array( 'twentytwentytwo-headers' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}},"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->
+
+					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
+					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+					<!-- /wp:navigation --></div>
+					<!-- /wp:group -->'
+);

--- a/inc/patterns/header-title-navigation-social.php
+++ b/inc/patterns/header-title-navigation-social.php
@@ -12,7 +12,7 @@ return array(
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 
-					<!-- wp:social-links {"iconColor":"foreground","iconColorValue":"#000000","className":"is-style-logos-only"} -->
+					<!-- wp:social-links {"iconColor":"foreground","iconColorValue":"var(--wp--preset--color--foreground)","className":"is-style-logos-only"} -->
 					<ul class="wp-block-social-links has-icon-color is-style-logos-only"><!-- wp:social-link {"url":"#","service":"instagram"} /-->
 
 					<!-- wp:social-link {"url":"#","service":"twitter"} /--></ul>

--- a/inc/patterns/header-title-navigation-social.php
+++ b/inc/patterns/header-title-navigation-social.php
@@ -3,10 +3,10 @@
  * Title, Navigation, and Social Links Header block pattern
  */
 return array(
-	'title'       => __( 'Title, Navigation, and Social Links Header', 'twentytwentytwo' ),
-	'categories'  => array( 'twentytwentytwo-headers' ),
+	'title'      => __( 'Title, Navigation, and Social Links Header', 'twentytwentytwo' ),
+	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /-->
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
@@ -18,5 +18,5 @@ return array(
 					<!-- wp:social-link {"url":"#","service":"twitter"} /--></ul>
 					<!-- /wp:social-links -->
 					<!-- /wp:navigation --></div>
-					<!-- /wp:group -->'
+					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-title-navigation-social.php
+++ b/inc/patterns/header-title-navigation-social.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Title, Navigation, and Social Links Header', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /-->
+	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /-->
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
@@ -17,6 +17,6 @@ return array(
 
 					<!-- wp:social-link {"url":"#","service":"twitter"} /--></ul>
 					<!-- /wp:social-links -->
-					<!-- /wp:navigation --></div>
+					<!-- /wp:navigation --></header>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-title-navigation-social.php
+++ b/inc/patterns/header-title-navigation-social.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Title, Navigation, and Social Links Header', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /-->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /-->
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
@@ -17,6 +17,6 @@ return array(
 
 					<!-- wp:social-link {"url":"#","service":"twitter"} /--></ul>
 					<!-- /wp:social-links -->
-					<!-- /wp:navigation --></header>
+					<!-- /wp:navigation --></div>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-title-navigation-social.php
+++ b/inc/patterns/header-title-navigation-social.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Title, Navigation, and Social Links Header block pattern
+ */
+return array(
+	'title'       => __( 'Title, Navigation, and Social Links Header', 'twentytwentytwo' ),
+	'categories'  => array( 'twentytwentytwo-headers' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /-->
+
+					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
+					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+
+					<!-- wp:social-links {"iconColor":"foreground","iconColorValue":"#000000","className":"is-style-logos-only"} -->
+					<ul class="wp-block-social-links has-icon-color is-style-logos-only"><!-- wp:social-link {"url":"#","service":"instagram"} /-->
+
+					<!-- wp:social-link {"url":"#","service":"twitter"} /--></ul>
+					<!-- /wp:social-links -->
+					<!-- /wp:navigation --></div>
+					<!-- /wp:group -->'
+);

--- a/inc/patterns/header-with-tagline.php
+++ b/inc/patterns/header-with-tagline.php
@@ -3,10 +3,10 @@
  * Header with Tagline block pattern
  */
 return array(
-	'title'       => __( 'Header with Tagline', 'twentytwentytwo' ),
-	'categories'  => array( 'twentytwentytwo-headers' ),
+	'title'      => __( 'Header with Tagline', 'twentytwentytwo' ),
+	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
 					<div class="wp-block-group"><!-- wp:site-logo {"width":64} /-->
 
@@ -20,5 +20,5 @@ return array(
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 					<!-- /wp:navigation --></div>
-					<!-- /wp:group -->'
+					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-with-tagline.php
+++ b/inc/patterns/header-with-tagline.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Header with Tagline', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
+	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
 					<div class="wp-block-group"><!-- wp:site-logo {"width":64} /-->
 
 					<!-- wp:group -->
@@ -19,6 +19,6 @@ return array(
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-					<!-- /wp:navigation --></header>
+					<!-- /wp:navigation --></div>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-with-tagline.php
+++ b/inc/patterns/header-with-tagline.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Header with Tagline block pattern
+ */
+return array(
+	'title'       => __( 'Header with Tagline', 'twentytwentytwo' ),
+	'categories'  => array( 'twentytwentytwo-headers' ),
+	'blockTypes' => array( 'core/template-part/header' ),
+	'content'     => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
+					<div class="wp-block-group"><!-- wp:site-logo {"width":64} /-->
+
+					<!-- wp:group -->
+					<div class="wp-block-group"><!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->
+
+					<!-- wp:site-tagline {"fontSize":"small","style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /--></div>
+					<!-- /wp:group --></div>
+					<!-- /wp:group -->
+
+					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
+					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+					<!-- /wp:navigation --></div>
+					<!-- /wp:group -->'
+);

--- a/inc/patterns/header-with-tagline.php
+++ b/inc/patterns/header-with-tagline.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Header with Tagline', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
+	'content'    => '<!-- wp:group {"align":"wide","tagName":"header","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<header class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
 					<div class="wp-block-group"><!-- wp:site-logo {"width":64} /-->
 
 					<!-- wp:group -->
@@ -19,6 +19,6 @@ return array(
 
 					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-					<!-- /wp:navigation --></div>
+					<!-- /wp:navigation --></header>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-with-tagline.php
+++ b/inc/patterns/header-with-tagline.php
@@ -11,9 +11,9 @@ return array(
 					<div class="wp-block-group"><!-- wp:site-logo {"width":64} /-->
 
 					<!-- wp:group -->
-					<div class="wp-block-group"><!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->
+					<div class="wp-block-group"><!-- wp:site-title {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}},"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->
 
-					<!-- wp:site-tagline {"fontSize":"small","style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /--></div>
+					<!-- wp:site-tagline {"style":{"spacing":{"margin":{"top":"0.25em","bottom":"0px"}},"typography":{"fontStyle":"italic","fontWeight":"400"}},"fontSize":"small"} /--></div>
 					<!-- /wp:group --></div>
 					<!-- /wp:group -->
 


### PR DESCRIPTION
**Description**

Addresses #14. (_Probably_ closes it for now at least). As per #12, we may move these to the directory at some point, but I think it makes sense to start building them in here to get started. 

This PR adds 12 of the block patterns from the initial designs:

<img width="5800" alt="Header-Patterns" src="https://user-images.githubusercontent.com/1202812/136603349-3948e01c-3b10-4153-bcf2-97aac109f8ab.png">

The four that are marked with an ❌ were not possible to create with the current block controls. I think that's fine though... we can leave them out for now. 

Some technical notes: 

- I added these to a "Twenty Twenty-Two Headers" category. We'll have a lot of block patterns in this theme, so I think it makes sense to have multiple, specific categories. 
- This includes the default `header` and `header-large-dark` patterns as used in our block template parts. Theme template parts don't currently show up in the theme carousel, so I think this is a sound strategy? That should probably change though.
- A few of these don't wrap super-nicely on smaller screens. 😕
    -  Header with Tagline ([Screenshot](https://cloudup.com/cxBvFm2Oj3V))
    - Text-only Header with Tagline ([Screenshot](https://cloudup.com/cz_z0CveuCt))
    - Text-only Header with Tagline and all-caps Title ([Screenshot](https://cloudup.com/c4mv-0BEeLj))
- <strike>The vertical gap between the title and tagline on [**Header with Tagline**](https://cloudup.com/c7ph2HPsD_O) and [**Text-only Header with stacked Tagline**](https://cloudup.com/c6CvKVhG5B5) is clearly too big. I'm not sure if we can adjust that yet though?</strike>
- I opted not to include any left/right padding around the patterns themselves. In our templates I've been adding that to the [parent template part](https://github.com/WordPress/twentytwentytwo/blob/af5d31d52c364670a09c8f2a85f77c9a592ca2bd/block-templates/single.html#L1), since it needs to match up with [the padding around the `main` template](https://github.com/WordPress/twentytwentytwo/blob/af5d31d52c364670a09c8f2a85f77c9a592ca2bd/block-templates/single.html#L3) too. Keeping left/right padding out of the patterns seems more versatile than having it in there. 
- While editing this I realized that the Site Title in our `header.html` and `header-large-black.html` template parts is supposed to be italic in order to match the comps. I made that change here to sync things up. 

**Screenshots**

![block-patterns](https://user-images.githubusercontent.com/1202812/136609364-34c0cc7f-6d80-44dd-8562-e12d77851a0c.gif)

**Testing Instructions** 

1. Add a "Header" block.
2. Choose "New header"
3. Scroll through the carousel, insert the new patterns, and test them out. 
