### PR TITLE
fix: testing link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Twenty Twenty-Two is designed to be the most flexible default theme ever created
 
 If you would like to contribute code, the list of [open issues](https://github.com/WordPress/twentytwentytwo/issues) is a great place to start looking for tasks. [Pull requests](https://github.com/WordPress/twentytwentytwo/pulls) are preferred when linked to an existing issue.
 
-Contributing is not just for developers! There are many opportunities to help with [testing](](#getting-started)), triage, discussion, design, building patterns and templates, and more. Please look through [open issues](https://github.com/WordPress/twentytwentytwo/issues), and join in wherever you feel most comfortable. 
+Contributing is not just for developers! There are many opportunities to help with [testing](#getting-started), triage, discussion, design, building patterns and templates, and more. Please look through [open issues](https://github.com/WordPress/twentytwentytwo/issues), and join in wherever you feel most comfortable. 
 
 If you'd like to help with triage, let @jffng and @kjellr know here or in [WordPress.org's slack instance](https://make.wordpress.org/chat/). We'll help you get set up with the ability to add labels to issues and PRs. 
 


### PR DESCRIPTION
**Description**

The testing link 404's.

**Screenshots**

N/A

**Testing Instructions** 

1. `gh pr checkout 76`
2. Try clicking the "testing" link located in the Contributing section

