### PR TITLE
Try using global site padding

### DIFF
--- a/block-template-parts/footer.html
+++ b/block-template-parts/footer.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"max(1.25rem, 5vw)","top":"8rem","right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignwide" style="padding-top:8rem;padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:site-title {"level":0} /-->
+<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"8rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignwide" style="padding-top:8rem"><!-- wp:site-title {"level":0} /-->
 
 <!-- wp:paragraph {"align":"right"} -->
 <p class="has-text-align-right">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>

--- a/block-template-parts/header-large-dark.html
+++ b/block-template-parts/header-large-dark.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:template-part {"slug":"header","tagName":"header","layout":{"inherit":true},"align":"wide"} /-->
+<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"max(1.25rem, 5vw)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-bottom:max(1.25rem, 5vw)"><!-- wp:template-part {"slug":"header","tagName":"header","layout":{"inherit":true},"align":"wide"} /-->
 
 <!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column -->

--- a/block-template-parts/header.html
+++ b/block-template-parts/header.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
+<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignwide" style="padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
 <div class="wp-block-group">
 <!-- wp:site-logo {"width":64} /-->
 

--- a/block-templates/404.html
+++ b/block-templates/404.html
@@ -1,7 +1,7 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","layout":{"inherit":true}} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}}} -->
-<main class="wp-block-group" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"layout":{"inherit":true}} -->
+<!-- wp:group {"tagName":"main"} -->
+<main class="wp-block-group"><!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group"><!-- wp:heading {"style":{"typography":{"fontSize":"clamp(4rem, 40vw, 20rem)","fontWeight":"200","lineHeight":"0"}},"className":"has-text-align-center"} -->
 <h2 class="has-text-align-center" style="font-size:clamp(4rem, 40vw, 20rem);font-weight:200;line-height:0">404</h2>
 <!-- /wp:heading -->

--- a/block-templates/index.html
+++ b/block-templates/index.html
@@ -1,7 +1,7 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","layout":{"inherit":true}} /-->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}}} -->
-<div class="wp-block-group" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":12},"tagName":"main","displayLayout":{"type":"flex","columns":3},"layout":{"inherit":true}} -->
+<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":12},"tagName":"main","displayLayout":{"type":"flex","columns":3},"layout":{"inherit":true}} -->
 <main class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
 <!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 

--- a/block-templates/page-home.html
+++ b/block-templates/page-home.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header-large-dark","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}}} -->
-<main class="wp-block-group" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)">
+<!-- wp:group {"tagName":"main"} -->
+<main class="wp-block-group">
 <!-- wp:post-content {"layout":{"inherit":true}} /-->
 </main>
 <!-- /wp:group -->

--- a/block-templates/page.html
+++ b/block-templates/page.html
@@ -1,7 +1,7 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","layout":{"inherit":true}} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}}} -->
-<main class="wp-block-group" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"layout":{"inherit":true}} -->
+<!-- wp:group {"tagName":"main"} -->
+<main class="wp-block-group"><!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group"><!-- wp:post-title {"align":"wide"} /-->
 
 <!-- wp:post-featured-image {"align":"wide"} /-->

--- a/block-templates/single.html
+++ b/block-templates/single.html
@@ -1,7 +1,7 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","layout":{"inherit":true}} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}}} -->
-<main class="wp-block-group" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"layout":{"inherit":true}} -->
+<!-- wp:group {"tagName":"main"} -->
+<main class="wp-block-group"><!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group"><!-- wp:post-title {"align":"wide"} /-->
 
 <!-- wp:post-featured-image {"align":"wide"} /-->

--- a/theme.json
+++ b/theme.json
@@ -195,7 +195,8 @@
 			}
 		},
 		"spacing": {
-			"blockGap": "1.5rem"
+			"blockGap": "1.5rem",
+			"padding": "max(1.25rem, 5vw)"
 		},
 		"typography": {
 			"fontFamily": "var(--wp--preset--font-family--system-font)",


### PR DESCRIPTION
This PR is an attempt to use the new global site padding `theme.json` entry as introduced in https://github.com/WordPress/gutenberg/pull/35241.

For most templates, things look identical to what we had before: 

<img width="1414" alt="Screen Shot 2021-10-12 at 8 00 48 AM" src="https://user-images.githubusercontent.com/1202812/136952761-67ccabd9-833b-4479-bb09-781a4e71e22b.png">

... however there's one major issue: the padding also applies to items that are set to full-width. This means we cannot have the full-width dark header: 

<img width="1414" alt="Screen Shot 2021-10-12 at 7 56 36 AM" src="https://user-images.githubusercontent.com/1202812/136952831-6c7e55d3-2029-412e-b5e5-27bc10d4b6a7.png">

Similarly, full-width items in the post content do not extend to the edges of the screen ([they don't do that with our current approach either](https://github.com/WordPress/twentytwentytwo/issues/5)). Not sure the best way around this — but I'd expect that if an item is specifically set to appear full-width, Gutenberg should let it be full-width?