### PR TITLE
Fix footer padding

### DIFF
--- a/block-template-parts/footer.html
+++ b/block-template-parts/footer.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"max(1.25rem, 5vw)","top":"8rem","right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignwide" style="padding-top:8rem;padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:site-title {"level":0} /-->
+<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"max(1.25rem, 5vw)","top":"8rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignwide" style="padding-top:8rem;padding-bottom:max(1.25rem, 5vw)"><!-- wp:site-title {"level":0} /-->
 
 <!-- wp:paragraph {"align":"right"} -->
 <p class="has-text-align-right">Proudly Powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>

--- a/block-templates/404.html
+++ b/block-templates/404.html
@@ -18,4 +18,4 @@
 <!-- /wp:group --></main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} /-->

--- a/block-templates/index.html
+++ b/block-templates/index.html
@@ -26,4 +26,4 @@
 <!-- /wp:query --></div>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} /-->

--- a/block-templates/page-home.html
+++ b/block-templates/page-home.html
@@ -6,4 +6,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} /-->

--- a/block-templates/page.html
+++ b/block-templates/page.html
@@ -18,4 +18,4 @@
 <!-- wp:post-content {"layout":{"inherit":true}} /--></main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} /-->

--- a/block-templates/single.html
+++ b/block-templates/single.html
@@ -54,4 +54,4 @@
 <!-- /wp:group --></main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} /-->


### PR DESCRIPTION
The footer padding is currently placed inside of the footer template, which is different from the approach used for the header template part, and also results in the footer not lining up with the rest of the page. This PR moves the spacing into the templates themselves to match how we're handling the headers. 

Before|After
---|---
<img width="1149" alt="Screen Shot 2021-10-12 at 2 17 00 PM" src="https://user-images.githubusercontent.com/1202812/137008566-f109858c-d87c-4c1e-b55d-af14c278f705.png">|<img width="1149" alt="Screen Shot 2021-10-12 at 2 15 59 PM" src="https://user-images.githubusercontent.com/1202812/137008567-62a02569-ac7b-49f5-a31c-f37bc6429906.png">

(This is just a minor fix for the current site padding approach, so it's separate from any explorations over in https://github.com/WordPress/twentytwentytwo/pull/88)
