### PR TITLE
Create staging_workshop.yml

### DIFF
--- a/.github/workflows/staging_workshop.yml
+++ b/.github/workflows/staging_workshop.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Deploy-Theme
         uses: SamKirkland/FTP-Deploy-Action@3.1.1
         with:
-          ftp-server: sftp://sftp.pressable.com:22/htdocs/wp-content/themes/
+          ftp-server: sftp://sftp.pressable.com:22/htdocs/wp-content/themes/twentytwentytwo/
           ftp-username: ${{ secrets.STAGING_USER }}
           ftp-password: ${{ secrets.STAGING_PASSWORD }}
           git-ftp-args: --insecure

--- a/.github/workflows/staging_workshop.yml
+++ b/.github/workflows/staging_workshop.yml
@@ -1,0 +1,24 @@
+name: TwentyTwentyTwo Staging Workshop Deploy
+
+on:
+  # Triggers the workflow only for the trunk branch
+  push:
+    branches: [ trunk ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 
+        uses: actions/checkout@v2
+      - name: Deploy-Theme
+        uses: SamKirkland/FTP-Deploy-Action@3.1.1
+        with:
+          ftp-server: sftp://sftp.pressable.com:22/htdocs/wp-content/themes/
+          ftp-username: ${{ secrets.STAGING_USER }}
+          ftp-password: ${{ secrets.STAGING_PASSWORD }}
+          git-ftp-args: --insecure
+          local-dir: ./

--- a/.github/workflows/staging_workshop.yml
+++ b/.github/workflows/staging_workshop.yml
@@ -1,4 +1,4 @@
-name: TwentyTwentyTwo Staging Workshop Deploy
+name: Deploy to Test Site
 
 on:
   # Triggers the workflow only for the trunk branch


### PR DESCRIPTION
Adding a deploy action on changes to /trunk for https://twentytwentytwo-trunk.mystagingwebsite.com/

**Description**

This deploys the content of the repo to the /themes folder in the noted site.  The expectation is that this would be the "workshop" where there will be many examples of different types of content and edge conditions.

The "starting content" is the [theme-test-data](https://github.com/WPTT/theme-test-data).

A separate site (likely 2022.wordpress.net) should also be setup to be a more "public face" of the theme with content better designed to demonstrate the strengths of the theme and properly achieve the design targets.

`STAGING_USER` and `STAGING_PASSWORD` values will need to be stored as secrets in order for this action to work.

Addresses #21 (though I still think 2022.wordpress.net would benefit from an automated deployment alongside this)