### PR TITLE
WIP: Implement the webfonts API

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -29,84 +29,28 @@ if ( ! function_exists( 'twentytwentytwo_support' ) ) :
 
 endif;
 
-
-if ( ! function_exists( 'twentytwentytwo_styles' ) ) :
-
-	/**
-	 * Enqueue styles.
-	 *
-	 * @return void
-	 */
-	function twentytwentytwo_styles() {
-
-		// Register theme stylesheet.
-		wp_register_style( 'twentytwentytwo-style', '' );
-
-		// Add styles inline.
-		wp_add_inline_style( 'twentytwentytwo-style', twentytwentytwo_get_font_face_styles() );
-
-		// Add metadata to the CSS stylesheet.
-		wp_style_add_data( 'twentytwentytwo-style', 'path', get_template_directory() . '/style.css' );
-
-		// Enqueue theme stylesheet.
-		wp_enqueue_style( 'twentytwentytwo-style' );
-
-	}
-	add_action( 'wp_enqueue_scripts', 'twentytwentytwo_styles' );
-
+if ( function_exists( 'wp_register_webfonts' ) ) :
+	wp_register_webfonts(
+		array(
+			array(
+				'fontFamily'  => 'Source Serif Pro',
+				'fontWeight'  => '200 900',
+				'fontStyle'   => 'normal',
+				'fontStretch' => 'normal',
+				'src'         => get_theme_file_uri( 'assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2' ),
+				'provider'    => 'local',
+			),
+			array(
+				'fontFamily'  => 'Source Serif Pro',
+				'fontWeight'  => '200 900',
+				'fontStyle'   => 'italic',
+				'fontStretch' => 'normal',
+				'src'         => get_theme_file_uri( 'assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2' ),
+				'provider'    => 'local',
+			),
+		)
+	);
 endif;
-
-
-if ( ! function_exists( 'twentytwentytwo_editor_styles' ) ) :
-
-	/**
-	 * Enqueue editor styles.
-	 *
-	 * @return void
-	 */
-	function twentytwentytwo_editor_styles() {
-
-		// Add styles inline.
-		wp_add_inline_style( 'wp-block-library', twentytwentytwo_get_font_face_styles() );
-
-	}
-	add_action( 'admin_init', 'twentytwentytwo_editor_styles' );
-
-endif;
-
-
-if ( ! function_exists( 'twentytwentytwo_get_font_face_styles' ) ) :
-
-	/**
-	 * Get font face styles.
-	 * Called by functions twentytwentytwo_styles() and twentytwentytwo_editor_styles() above.
-	 *
-	 * @return string
-	 */
-	function twentytwentytwo_get_font_face_styles() {
-
-		return "
-		@font-face{
-			font-family: 'Source Serif Pro';
-			font-weight: 200 900;
-			font-style: normal;
-			font-stretch: normal;
-			src: url('" . get_theme_file_uri( 'assets/fonts/SourceSerif4Variable-Roman.ttf.woff2' ) . "') format('woff2');
-		}
-
-		@font-face{
-			font-family: 'Source Serif Pro';
-			font-weight: 200 900;
-			font-style: italic;
-			font-stretch: normal;
-			src: url('" . get_theme_file_uri( 'assets/fonts/SourceSerif4Variable-Italic.ttf.woff2' ) . "') format('woff2');
-		}
-		";
-
-	}
-
-endif;
-
 
 // Add block patterns
 require get_template_directory() . '/inc/block-patterns.php';


### PR DESCRIPTION
In https://github.com/WordPress/wordpress-develop/pull/1736 we're working on a webfonts API for WordPress Core.
This PR is a companion to the core patch, to test the API.

Eventually, the goal is to have webfonts defined in the `theme.json` file, but in this 1st iteration we're using a `wp_register_webfonts` function.