### PR TITLE
Simplify dark header template and pattern.

### DIFF
--- a/block-template-parts/header-large-dark.html
+++ b/block-template-parts/header-large-dark.html
@@ -1,13 +1,15 @@
-<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:template-part {"slug":"header","tagName":"header","layout":{"inherit":true},"align":"wide"} /-->
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","bottom":"8rem"},"margin":{"bottom":"8rem"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-right:max(1.25rem, 5vw);padding-bottom:8rem;padding-left:max(1.25rem, 5vw);margin-bottom:8rem"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
+<div class="wp-block-group"><!-- wp:site-logo {"width":64} /-->
 
-<!-- wp:columns {"align":"wide"} -->
-<div class="wp-block-columns alignwide"><!-- wp:column -->
-<div class="wp-block-column"><!-- wp:site-tagline {"style":{"typography":{"fontFamily":"var:preset|font-family|source-serif-pro","fontWeight":"300","fontSize":"clamp(4rem, 8vw, 6.25rem)","lineHeight":"1.15"}}} /--></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns --></div>
+<!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /--></div>
 <!-- /wp:group -->
 
-<!-- wp:spacer {"height":64} -->
-<div style="height:64px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+<!-- wp:navigation {"itemsJustification":"right"} -->
+<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+<!-- /wp:navigation --></div>
+<!-- /wp:group -->
+
+<!-- wp:site-tagline {"align":"wide","style":{"typography":{"fontFamily":"var:preset|font-family|source-serif-pro","fontWeight":"300","fontSize":"clamp(4rem, 8vw, 6.25rem)","lineHeight":"1.15"}}} /--></div>
+<!-- /wp:group -->

--- a/block-template-parts/header-large-dark.html
+++ b/block-template-parts/header-large-dark.html
@@ -6,7 +6,7 @@
 <!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /--></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"itemsJustification":"right"} -->
+<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 <!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 <!-- /wp:navigation --></div>
 <!-- /wp:group -->

--- a/inc/patterns/header-large-dark.php
+++ b/inc/patterns/header-large-dark.php
@@ -14,7 +14,7 @@ return array(
 					<!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /--></div>
 					<!-- /wp:group -->
 
-					<!-- wp:navigation {"itemsJustification":"right"} -->
+					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 					<!-- /wp:navigation --></div>
 					<!-- /wp:group -->

--- a/inc/patterns/header-large-dark.php
+++ b/inc/patterns/header-large-dark.php
@@ -6,24 +6,19 @@ return array(
 	'title'      => __( 'Large Header', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
-					<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","bottom":"8rem"},"margin":{"bottom":"8rem"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-right:max(1.25rem, 5vw);padding-bottom:8rem;padding-left:max(1.25rem, 5vw);margin-bottom:8rem"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->
-					<div class="wp-block-group">
-					<!-- wp:site-logo {"width":64} /-->
+					<div class="wp-block-group"><!-- wp:site-logo {"width":64} /-->
 
 					<!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /--></div>
 					<!-- /wp:group -->
 
-					<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
+					<!-- wp:navigation {"itemsJustification":"right"} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 					<!-- /wp:navigation --></div>
 					<!-- /wp:group -->
 
-					<!-- wp:columns {"align":"wide"} -->
-					<div class="wp-block-columns alignwide"><!-- wp:column -->
-					<div class="wp-block-column"><!-- wp:site-tagline {"style":{"typography":{"fontFamily":"var:preset|font-family|source-serif-pro","fontWeight":"300","fontSize":"clamp(4rem, 8vw, 6.25rem)","lineHeight":"1.15"}}} /--></div>
-					<!-- /wp:column --></div>
-					<!-- /wp:columns --></div>
+					<!-- wp:site-tagline {"align":"wide","style":{"typography":{"fontFamily":"var:preset|font-family|source-serif-pro","fontWeight":"300","fontSize":"clamp(4rem, 8vw, 6.25rem)","lineHeight":"1.15"}}} /--></div>
 					<!-- /wp:group -->',
 );


### PR DESCRIPTION
This PR simplifies the block setup for the Dark header template and pattern (used on the  homepage). 

- It relies on the recently-merged https://github.com/WordPress/gutenberg/pull/35589 to make the site tagline wide-width. Previously, the tagline was wrapped in a columns block that added a bunch of extra unnecessary margins. 
- Since that weird extra margin is gone, this PR also re-adjusts some of the paddings/margin to make things look a little bit more even. 

When testing, you'll need to be running the latest Gutenberg `trunk`. (If it works, I think it's fine to merge this in now, even though that change hasn't made it to the plugin yet). 

Before|After
---|---
![Screen Shot 2021-10-13 at 09 01 33](https://user-images.githubusercontent.com/1202812/137138228-5e5d036c-b350-46c5-941b-e54937664f96.png)|![Screen Shot 2021-10-13 at 09 01 06](https://user-images.githubusercontent.com/1202812/137138231-a0f37112-367e-4da3-9f0e-45c97a01a75a.png)