### PR TITLE
Fix WordPress link internationalization in footer patterns

### DIFF
--- a/inc/patterns/footer-blog.php
+++ b/inc/patterns/footer-blog.php
@@ -43,7 +43,7 @@ return array(
 					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title /-->
 
 					<!-- wp:paragraph {"align":"right"} -->
-					<p class="has-text-align-right">' . esc_html__( 'Proudly powered by ', 'twentytwentyone' ) . '<a href="' . esc_url( 'https://wordpress.org' ) . '" rel="nofollow">WordPress</a></p>
+					<p class="has-text-align-right">' . esc_html__( 'Proudly powered by ', 'twentytwentyone' ) . '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a></p>
 					<!-- /wp:paragraph --></div>
 					<!-- /wp:group --></div>
 					<!-- /wp:group -->',

--- a/inc/patterns/footer-dark.php
+++ b/inc/patterns/footer-dark.php
@@ -11,7 +11,7 @@ return array(
 					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title /-->
 
 					<!-- wp:paragraph {"align":"right"} -->
-					<p class="has-text-align-right">' . esc_html__( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="' . esc_url( 'https://wordpress.org' ) . '" rel="nofollow">WordPress</a></p>
+					<p class="has-text-align-right">' . esc_html__( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a></p>
 					<!-- /wp:paragraph --></div>
 					<!-- /wp:group --></div>
 					<!-- /wp:group -->',

--- a/inc/patterns/footer-default.php
+++ b/inc/patterns/footer-default.php
@@ -11,7 +11,7 @@ return array(
 					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title /-->
 
 					<!-- wp:paragraph {"align":"right"} -->
-					<p class="has-text-align-right">' . esc_html__( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="' . esc_url( 'https://wordpress.org' ) . '" rel="nofollow">WordPress</a></p>
+					<p class="has-text-align-right">' . esc_html__( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a></p>
 					<!-- /wp:paragraph --></div>
 					<!-- /wp:group --></div>
 					<!-- /wp:group -->',

--- a/inc/patterns/footer-logo.php
+++ b/inc/patterns/footer-logo.php
@@ -11,7 +11,7 @@ return array(
 					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-logo {"width":60} /-->
 
 					<!-- wp:paragraph {"align":"right"} -->
-					<p class="has-text-align-right">' . esc_html__( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="' . esc_url( 'https://wordpress.org' ) . '" rel="nofollow">WordPress</a></p>
+					<p class="has-text-align-right">' . esc_html__( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a></p>
 					<!-- /wp:paragraph --></div>
 					<!-- /wp:group --></div>
 					<!-- /wp:group -->',

--- a/inc/patterns/footer-navigation.php
+++ b/inc/patterns/footer-navigation.php
@@ -13,7 +13,7 @@ return array(
 					<!-- /wp:navigation -->
 
 					<!-- wp:paragraph {"align":"right"} -->
-					<p class="has-text-align-right">' . esc_html__( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="' . esc_url( 'https://wordpress.org' ) . '" rel="nofollow">WordPress</a></p>
+					<p class="has-text-align-right">' . esc_html__( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a></p>
 					<!-- /wp:paragraph --></div>
 					<!-- /wp:group --></div>
 					<!-- /wp:group -->',

--- a/inc/patterns/footer-query-images-title-citation.php
+++ b/inc/patterns/footer-query-images-title-citation.php
@@ -27,7 +27,7 @@ return array(
 					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title /-->
 
 					<!-- wp:paragraph {"align":"right"} -->
-					<p class="has-text-align-right">' . esc_html__( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="' . esc_url( 'https://wordpress.org' ) . '" rel="nofollow">WordPress</a></p>
+					<p class="has-text-align-right">' . esc_html__( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a></p>
 					<!-- /wp:paragraph --></div>
 					<!-- /wp:group --></div>
 					<!-- /wp:group -->',

--- a/inc/patterns/footer-query-title-citation.php
+++ b/inc/patterns/footer-query-title-citation.php
@@ -25,7 +25,7 @@ return array(
 					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title /-->
 
 					<!-- wp:paragraph {"align":"right"} -->
-					<p class="has-text-align-right">' . esc_html__( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="' . esc_url( 'https://wordpress.org' ) . '" rel="nofollow">WordPress</a></p>
+					<p class="has-text-align-right">' . esc_html__( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a></p>
 					<!-- /wp:paragraph --></div>
 					<!-- /wp:group --></div>
 					<!-- /wp:group -->',


### PR DESCRIPTION
**Description**

The "WordPress" link in footer patterns needs to be translatable, since Locales will replace the link with the link to the Rosetta website.

**Screenshots**

Not applicable.

**Testing Instructions** 

Not easily testable, but I tested to insert the edited patterns and it works fine :)
