### PR TITLE
Tidy up post meta

### DIFF
--- a/block-templates/single.html
+++ b/block-templates/single.html
@@ -30,17 +30,15 @@
 <!-- wp:group -->
 <div class="wp-block-group"><!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column {"width":"66.66%","style":{"spacing":{"padding":{"top":"0%","right":"0%","bottom":"0%","left":"0%"}}}} -->
-<div class="wp-block-column" style="padding-top:0%;padding-right:0%;padding-bottom:0%;padding-left:0%;flex-basis:66.66%"><!-- wp:group {"layout":{"type":"flex"}} -->
-<div class="wp-block-group"><!-- wp:post-date {"fontSize":"small"} /-->
-
-<!-- wp:post-terms {"term":"category","fontSize":"small"} /--></div>
-<!-- /wp:group -->
+<div class="wp-block-column" style="padding-top:0%;padding-right:0%;padding-bottom:0%;padding-left:0%;flex-basis:66.66%"><!-- wp:post-date {"fontSize":"small"} /-->
 
 <!-- wp:post-author {"showAvatar":false,"fontSize":"small"} /--></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class="wp-block-column"><!-- wp:post-terms {"term":"post_tag","fontSize":"small"} /--></div>
+<div class="wp-block-column"><!-- wp:post-terms {"term":"category","fontSize":"small"} /-->
+
+<!-- wp:post-terms {"term":"post_tag","fontSize":"small"} /--></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
 <!-- /wp:group --></div>

--- a/block-templates/single.html
+++ b/block-templates/single.html
@@ -27,20 +27,14 @@
 <hr class="wp-block-separator alignwide is-style-wide"/>
 <!-- /wp:separator -->
 
-<!-- wp:group -->
-<div class="wp-block-group"><!-- wp:columns -->
-<div class="wp-block-columns"><!-- wp:column {"width":"66.66%","style":{"spacing":{"padding":{"top":"0%","right":"0%","bottom":"0%","left":"0%"}}}} -->
-<div class="wp-block-column" style="padding-top:0%;padding-right:0%;padding-bottom:0%;padding-left:0%;flex-basis:66.66%"><!-- wp:post-date {"fontSize":"small"} /-->
+<!-- wp:group {"layout":{"type":"flex"}} -->
+<div class="wp-block-group"><!-- wp:post-date {"fontSize":"small"} /-->
 
-<!-- wp:post-author {"showAvatar":false,"fontSize":"small"} /--></div>
-<!-- /wp:column -->
+<!-- wp:post-author {"showAvatar":false,"fontSize":"small"} /-->
 
-<!-- wp:column -->
-<div class="wp-block-column"><!-- wp:post-terms {"term":"category","fontSize":"small"} /-->
+<!-- wp:post-terms {"term":"category","fontSize":"small"} /-->
 
 <!-- wp:post-terms {"term":"post_tag","fontSize":"small"} /--></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/theme.json
+++ b/theme.json
@@ -116,11 +116,6 @@
 					"text": "var(--wp--preset--color--background)"
 				}
 			},
-			"core/post-author": {
-				"typography": {
-					"fontWeight": "normal"
-				}
-			},
 			"core/post-title": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--source-serif-pro)",

--- a/theme.json
+++ b/theme.json
@@ -116,6 +116,11 @@
 					"text": "var(--wp--preset--color--background)"
 				}
 			},
+			"core/post-author": {
+				"typography": {
+					"fontWeight": "normal"
+				}
+			},
 			"core/post-title": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--source-serif-pro)",


### PR DESCRIPTION
This PR does some minor cleanup to the post meta. It just puts everything on one line. 

It's not what we had originally mocked up, but I think is more versatile. I may re-think it later on but in the meantime this is cleaner than what we have. 

**Before:** 
<img width="1088" alt="Screen Shot 2021-10-14 at 3 58 09 PM" src="https://user-images.githubusercontent.com/1202812/137387118-b3bdb4ae-d908-4bdb-91eb-c15b2a0e711a.png">

**After:**
<img width="1043" alt="Screen Shot 2021-10-14 at 4 02 57 PM" src="https://user-images.githubusercontent.com/1202812/137387468-fb59532f-8153-49bd-8ee1-ebf616b9738a.png">

