### PR TITLE
Footer patterns: allow translators to control the whole credit string

### DIFF
--- a/inc/patterns/footer-default.php
+++ b/inc/patterns/footer-default.php
@@ -11,7 +11,12 @@ return array(
 					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title /-->
 
 					<!-- wp:paragraph {"align":"right"} -->
-					<p class="has-text-align-right">' . esc_html__( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a></p>
+					<p class="has-text-align-right">' .
+					sprintf(
+						/* Translators: WordPress link. */
+						esc_html__( 'Proudly powered by %s', 'twentytwentytwo' ),
+						'<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a>'
+					) . '</p>
 					<!-- /wp:paragraph --></div>
 					<!-- /wp:group --></div>
 					<!-- /wp:group -->',

--- a/inc/patterns/footer-logo.php
+++ b/inc/patterns/footer-logo.php
@@ -11,7 +11,12 @@ return array(
 					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-logo {"width":60} /-->
 
 					<!-- wp:paragraph {"align":"right"} -->
-					<p class="has-text-align-right">' . esc_html__( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a></p>
+					<p class="has-text-align-right">' .
+					sprintf(
+						/* Translators: WordPress link. */
+						esc_html__( 'Proudly powered by %s', 'twentytwentytwo' ),
+						'<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a>'
+					) . '</p>
 					<!-- /wp:paragraph --></div>
 					<!-- /wp:group --></div>
 					<!-- /wp:group -->',

--- a/inc/patterns/footer-navigation.php
+++ b/inc/patterns/footer-navigation.php
@@ -13,7 +13,12 @@ return array(
 					<!-- /wp:navigation -->
 
 					<!-- wp:paragraph {"align":"right"} -->
-					<p class="has-text-align-right">' . esc_html__( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a></p>
+					<p class="has-text-align-right">' .
+					sprintf(
+						/* Translators: WordPress link. */
+						esc_html__( 'Proudly powered by %s', 'twentytwentytwo' ),
+						'<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a>'
+					) . '</p>
 					<!-- /wp:paragraph --></div>
 					<!-- /wp:group --></div>
 					<!-- /wp:group -->',

--- a/inc/patterns/footer-query-images-title-citation.php
+++ b/inc/patterns/footer-query-images-title-citation.php
@@ -27,7 +27,12 @@ return array(
 					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title /-->
 
 					<!-- wp:paragraph {"align":"right"} -->
-					<p class="has-text-align-right">' . esc_html__( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a></p>
+					<p class="has-text-align-right">' .
+					sprintf(
+						/* Translators: WordPress link. */
+						esc_html__( 'Proudly powered by %s', 'twentytwentytwo' ),
+						'<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a>'
+					) . '</p>
 					<!-- /wp:paragraph --></div>
 					<!-- /wp:group --></div>
 					<!-- /wp:group -->',

--- a/inc/patterns/footer-query-title-citation.php
+++ b/inc/patterns/footer-query-title-citation.php
@@ -25,7 +25,12 @@ return array(
 					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title /-->
 
 					<!-- wp:paragraph {"align":"right"} -->
-					<p class="has-text-align-right">' . esc_html__( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a></p>
+					<p class="has-text-align-right">' .
+					sprintf(
+						/* Translators: WordPress link. */
+						esc_html__( 'Proudly powered by %s', 'twentytwentytwo' ),
+						'<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a>'
+					) . '</p>
 					<!-- /wp:paragraph --></div>
 					<!-- /wp:group --></div>
 					<!-- /wp:group -->',


### PR DESCRIPTION
**Description**

For footer patterns with WordPress credit links, translators will need to be able to control the whole sentence. 

Here is the current implementation:
```
esc_html__( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a></p>
```

Depending on their language, translator may need to move the "WordPress" link at the beginning of the sentence, for example. Therefore, we need to use a placeholder for the link.

Proposal:
```
sprintf(
	/* Translators: WordPress link. */
	esc_html__( 'Proudly powered by %s', 'twentytwentytwo' ),
	'<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a>'
)
```

I tested this change with the related patterns and and it doesn't change anything to the current rendering.