### PR TITLE
Add Support for Post Thumbnails / Featured Images

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -6,7 +6,6 @@ if ( ! function_exists( 'twentytwentytwo_support' ) ) :
 		add_theme_support( 'wp-block-styles' );
 		// Adding support for featured images
 		add_theme_support( 'post-thumbnails' );
-
 	}
 	add_action( 'after_setup_theme', 'twentytwentytwo_support' );
 endif;

--- a/functions.php
+++ b/functions.php
@@ -4,6 +4,9 @@ if ( ! function_exists( 'twentytwentytwo_support' ) ) :
 	function twentytwentytwo_support() {
 		// Adding support for core block visual styles.
 		add_theme_support( 'wp-block-styles' );
+		// Adding support for featured images
+		add_theme_support( 'post-thumbnails' );
+
 	}
 	add_action( 'after_setup_theme', 'twentytwentytwo_support' );
 endif;


### PR DESCRIPTION
The theme currently uses Post Thumbnails in templates, but without explicitly declaring support for it, it is impossible to edit them or add new ones.

**Description**

In [multiple places the theme uses the featured image](https://github.com/WordPress/twentytwentytwo/search?q=wp%3Apost-featured-image), let's make it possible to also edit them
