### PR TITLE
Update quote + pullquote borders

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -126,13 +126,11 @@
 			},
 			"core/pullquote": {
 				"border": {
-					"style": "solid",
 					"width": "1px 0"
 				}
 			},
 			"core/quote": {
 				"border": {
-					"style": "solid",
 					"width": "0 0 0 1px"
 				}
 			},

--- a/theme.json
+++ b/theme.json
@@ -124,6 +124,18 @@
 					"fontSize": "var(--wp--custom--typography--font-size--gigantic)"
 				}
 			},
+			"core/pullquote": {
+				"border": {
+					"style": "solid",
+					"width": "1px 0"
+				}
+			},
+			"core/quote": {
+				"border": {
+					"style": "solid",
+					"width": "0 0 0 1px"
+				}
+			},
 			"core/site-title": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--system-font)",


### PR DESCRIPTION
Fixes #103
Partially addresses #102

This PR updates the borders for the quote + pull quote so that they're both 1px wide. 

Before|After
---|---
<img width="686" alt="Screen Shot 2021-10-18 at 11 35 20 AM" src="https://user-images.githubusercontent.com/1202812/137763408-a620cc35-a119-4a78-928d-fb89e9843f9d.png">|<img width="700" alt="Screen Shot 2021-10-18 at 11 35 08 AM" src="https://user-images.githubusercontent.com/1202812/137763430-69bbc17e-efe9-40ea-bc45-60707c3d1bd5.png">
