### PR TITLE
Set default text size for buttons

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -155,6 +155,9 @@
 				"color": {
 					"background": "var(--wp--preset--color--primary)",
 					"text": "var(--wp--preset--color--background)"
+				},
+				"typography": {
+					"fontSize": "var(--wp--preset--typography--font-size--normal)"
 				}
 			},
 			"core/post-title": {


### PR DESCRIPTION
[As per the mockups](https://www.figma.com/file/76mfUcaK4QDlrXElk8MK3H/?node-id=729%3A4866), the default text size for buttons should be our `normal` font size. They're currently actually a bit larger than that. 

Before|After
---|---
<img width="391" alt="Screen Shot 2021-10-19 at 10 19 56 AM" src="https://user-images.githubusercontent.com/1202812/137929444-dd1411bb-b2df-40ba-bb2d-3460836b0c6b.png">|<img width="394" alt="Screen Shot 2021-10-19 at 10 19 44 AM" src="https://user-images.githubusercontent.com/1202812/137929487-5e9a4c73-2739-460a-ad30-bb83eb405a14.png">
