### PR TITLE
Add custom margin support

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -89,6 +89,7 @@
 		},
 		"spacing": {
 			"blockGap": true,
+			"customMargin": true,
 			"customPadding": true,
 			"units": [
 				"%",


### PR DESCRIPTION
Adds support for showing custom margin controls, if the block supports them. We already support custom padding, so I don't see a reason not to support this too.