### PR TITLE
Fix index template markup

### DIFF
--- a/block-templates/index.html
+++ b/block-templates/index.html
@@ -28,7 +28,7 @@
 
 <!-- wp:spacer {"height":112} -->
 <div style="height:112px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+<!-- /wp:spacer --></div>
 <!-- /wp:group -->
 <!-- /wp:post-template -->
 


### PR DESCRIPTION
**Description**

There was a bug in the block markup from #136, I missed a closing div on the index template. This PR adds it back. 

I did test with removing this group block entirely, and it seemed fine, but I think it's better to keep the group to contain all the related elements of the post template.

**Testing Instructions** 

Go to the site editor and front-end, verify there are no errors.