### PR TITLE
Adjust date formats in query patterns

### DIFF
--- a/inc/patterns/query-image-grid.php
+++ b/inc/patterns/query-image-grid.php
@@ -13,7 +13,7 @@ return array(
 					<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"style":{"typography":{"fontFamily":"var:preset|font-family|system-font","fontStyle":"normal","fontWeight":"400"}},"fontSize":"small"} /-->
 
-					<!-- wp:post-date {"format":"F j, Y","style":{"typography":{"fontStyle":"italic","fontWeight":"400"}},"fontSize":"small"} /--></div>
+					<!-- wp:post-date {"format":"m.d.y","style":{"typography":{"fontStyle":"italic","fontWeight":"400"}},"fontSize":"small"} /--></div>
 					<!-- /wp:group -->
 					<!-- /wp:post-template -->
 

--- a/inc/patterns/query-large-titles.php
+++ b/inc/patterns/query-large-titles.php
@@ -9,8 +9,8 @@ return array(
 	'content'    => '<!-- wp:query {"query":{"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"perPage":8},"align":"wide"} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template -->
 					<!-- wp:columns -->
-					<div class="wp-block-columns"><!-- wp:column {"verticalAlignment":"top","width":"160px"} -->
-					<div class="wp-block-column is-vertically-aligned-top" style="flex-basis:160px"><!-- wp:post-date {"fontSize":"small"} /--></div>
+					<div class="wp-block-columns"><!-- wp:column {"verticalAlignment":"top","width":"4em"} -->
+					<div class="wp-block-column is-vertically-aligned-top" style="flex-basis:4em"><!-- wp:post-date {"format":"M j","fontSize":"small"} /--></div>
 					<!-- /wp:column -->
 
 					<!-- wp:column {"verticalAlignment":"center","width":""} -->


### PR DESCRIPTION
Addresses two of the checkboxes in https://github.com/WordPress/twentytwentytwo/issues/90:

- Image grid posts: Post date can not be formatted into the "11.11.2021" format as originally designed.
- Large post titles: Post date can not be formatted into the "Nov 11" format as originally designed.

Note that this uses custom (valid) markup in the block to get this to work. When you have one of these selected, the date format dropdown will show an incorrect value. There's an upstream bug filed for that here: https://github.com/WordPress/gutenberg/issues/35854

## Screenshots

Before|After
---|---
<img width="238" alt="Screen Shot 2021-10-21 at 3 21 08 PM" src="https://user-images.githubusercontent.com/1202812/138344141-52db1245-6f0e-4de6-8171-f60045c41b3a.png">|<img width="232" alt="Screen Shot 2021-10-21 at 3 17 45 PM" src="https://user-images.githubusercontent.com/1202812/138344142-0f478b30-b3d8-4954-a0e6-5633432ca782.png">

Before|After
---|---
<img width="1026" alt="Screen Shot 2021-10-21 at 3 20 45 PM" src="https://user-images.githubusercontent.com/1202812/138344177-3a31b288-6207-4f15-85f3-7917b8101f8e.png">|<img width="1031" alt="Screen Shot 2021-10-21 at 3 20 19 PM" src="https://user-images.githubusercontent.com/1202812/138344178-14248214-5eaf-496c-b40d-61e8a5970c47.png">

