### PR TITLE
add duotone preset

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -33,6 +33,38 @@
 	],
 	"settings": {
 		"color": {
+			"duotone": [
+                {
+                    "colors": [ "#000000", "#ffffff" ],
+                    "slug": "foreground-and-background",
+                    "name": "Foreground and background"
+                },
+				{
+                    "colors": [ "#000000", "#ffe2c7" ],
+                    "slug": "foreground-and-secondary",
+                    "name": "Foreground and secondary"
+                },
+				{
+                    "colors": [ "#000000", "#f6f6f6" ],
+                    "slug": "foreground-and-tertiary",
+                    "name": "Foreground and tertiary"
+                },
+				{
+                    "colors": [ "#1a4548", "#ffffff" ],
+                    "slug": "primary-and-background",
+                    "name": "Primary and background"
+                },
+				{
+                    "colors": [ "#1a4548", "#ffe2c7" ],
+                    "slug": "primary-and-secondary",
+                    "name": "Primary and secondary"
+                },
+				{
+                    "colors": [ "#1a4548", "#f6f6f6" ],
+                    "slug": "primary-and-tertiary",
+                    "name": "Primary and tertiary"
+                }
+            ],
 			"gradients": [
 				{
 					"slug": "vertical-secondary-to-tertiary",


### PR DESCRIPTION
Add duotone preset to theme.json based on theme colors

Solves #140

I’d like to note that the difference between the foreground and tertiary colors is visually hardly noticeable:

![duotone-presets](https://user-images.githubusercontent.com/5901923/138695354-be739d5d-ecdd-4fb5-81d2-e21f1c765d22.png)

