### PR TITLE
Add simple version of button hover state

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -13,13 +13,10 @@ if ( ! function_exists( 'twentytwentytwo_styles' ) ) :
 	 * Enqueue scripts and styles.
 	 */
 	function twentytwentytwo_styles() {
-		// Register theme stylesheet.
-		wp_register_style( 'twentytwentytwo-style', '' );
+		// Register theme stylesheet
+		wp_enqueue_style( 'twentytwentytwo-style', get_stylesheet_uri() );
 		// Add styles inline.
 		wp_add_inline_style( 'twentytwentytwo-style', twentytwentytwo_get_font_face_styles() );
-		// Enqueue theme stylesheet.
-		wp_style_add_data( 'twentytwentytwo-style', 'path', get_template_directory() . '/style.css' );
-		wp_enqueue_style( 'twentytwentytwo-style' );
 	}
 	add_action( 'wp_enqueue_scripts', 'twentytwentytwo_styles' );
 endif;
@@ -29,7 +26,9 @@ if ( ! function_exists( 'twentytwentytwo_editor_styles' ) ) :
 	 * Enqueue editor styles.
 	 */
 	function twentytwentytwo_editor_styles() {
-		wp_add_inline_style( 'wp-block-library', twentytwentytwo_get_font_face_styles() );
+		// Register theme stylesheet
+		wp_enqueue_style( 'twentytwentytwo-style', get_stylesheet_uri() );
+		wp_add_inline_style( 'twentytwentytwo-style', twentytwentytwo_get_font_face_styles() );
 	}
 	add_action( 'admin_init', 'twentytwentytwo_editor_styles' );
 endif;

--- a/style.css
+++ b/style.css
@@ -18,84 +18,72 @@ Twenty Twenty-Two is distributed under the terms of the GNU GPL.
 */
 
 /**
- * Button
+ * Button Styles
  */
-/**
- * Block Options
- */
- .wp-block-button.wp-block-button__link,
- .wp-block-button .wp-block-button__link {
-	 border-width: 0;
-	 padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
-	 padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
-	 padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
-	 padding-right: calc( var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width));
-	 text-decoration: none;
- }
- 
- .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
- .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
- .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
- .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
-	 --wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
-	 --wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-	 --wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
-	 opacity: 1;
-	 color: var(--wp--custom--button--color--text);
-	 background-color: var(--wp--custom--button--color--background);
-	 border-color: currentColor;
-	 border-color: var(--wp--custom--button--border--color);
- }
- 
- .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
- .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
- .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
- .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
-	 fill: var(--wp--custom--button--color--text);
- }
- 
- .wp-block-button.is-style-outline.wp-block-button__link,
- .wp-block-button.is-style-outline .wp-block-button__link {
-	 --wp--custom--button--color--text: var(--wp--custom--button--border--color);
-	 --wp--custom--button--color--background: transparent;
-	 border-style: var(--wp--custom--button--border--style);
-	 border-width: var(--wp--custom--button--border--width);
-	 padding-top: var(--wp--custom--button--spacing--padding--top);
-	 padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
-	 padding-left: var(--wp--custom--button--spacing--padding--left);
-	 padding-right: var(--wp--custom--button--spacing--padding--right);
-	 opacity: 1;
-	 color: var(--wp--custom--button--color--text);
-	 background-color: var(--wp--custom--button--color--background);
-	 border-color: currentColor;
- }
- 
- .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
- .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
- .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
- .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
-	 --wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
-	 --wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-	 --wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
-	 opacity: 1;
-	 color: var(--wp--custom--button--color--text);
-	 background-color: var(--wp--custom--button--color--background);
-	 border-color: currentColor;
-	 border-color: var(--wp--custom--button--border--color);
- }
- 
- .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
- .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
- .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
- .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
-	 fill: var(--wp--custom--button--color--text);
- }
- 
- .wp-block-button.is-style-outline.wp-block-button__link svg,
- .wp-block-button.is-style-outline .wp-block-button__link svg {
-	 fill: var(--wp--custom--button--color--text);
- }
- 
- .wp-block-buttons .wp-block-button:last-child {
-	 margin-bottom: 0;
- }
+.wp-block-button .wp-block-button__link {
+	border-width: 0;
+	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
+	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
+	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
+	padding-right: calc( var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width));
+	text-decoration: none;
+}
+
+.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
+.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
+.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
+	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
+	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
+	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
+	border-color: currentColor;
+	border-style: var(--wp--custom--button--border--style);
+	border-width: var(--wp--custom--button--border--width);
+	padding-top: var(--wp--custom--button--spacing--padding--top);
+	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
+	padding-left: var(--wp--custom--button--spacing--padding--left);
+	padding-right: var(--wp--custom--button--spacing--padding--right);
+}
+
+.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
+.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
+.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
+	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-button.is-style-outline .wp-block-button__link {
+	--wp--custom--button--color--text: var(--wp--custom--button--border--color);
+	--wp--custom--button--color--background: transparent;
+	background-color: var(--wp--custom--button--color--background);
+	border-color: currentColor;
+	border-style: var(--wp--custom--button--border--style);
+	border-width: var(--wp--custom--button--border--width);
+	color: var(--wp--custom--button--color--text);
+	padding-top: var(--wp--custom--button--spacing--padding--top);
+	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
+	padding-left: var(--wp--custom--button--spacing--padding--left);
+	padding-right: var(--wp--custom--button--spacing--padding--right);
+}
+
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
+	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
+	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
+	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
+	color: var(--wp--custom--button--color--text);
+	background-color: var(--wp--custom--button--color--background);
+	border-color: currentColor;
+	border-color: var(--wp--custom--button--border--color);
+}
+
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
+	fill: var(--wp--custom--button--color--text);
+}
+
+.wp-block-button.is-style-outline .wp-block-button__link svg {
+	fill: var(--wp--custom--button--color--text);
+}

--- a/style.css
+++ b/style.css
@@ -18,72 +18,15 @@ Twenty Twenty-Two is distributed under the terms of the GNU GPL.
 */
 
 /**
- * Button Styles
+ * Button Hover Styles for default and outline buttons
  */
-.wp-block-button .wp-block-button__link {
-	border-width: 0;
-	padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
-	padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
-	padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
-	padding-right: calc( var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width));
-	text-decoration: none;
-}
-
-.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
-.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
-.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
-	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
-	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
-	color: var(--wp--custom--button--color--text);
-	background-color: var(--wp--custom--button--color--background);
-	border-color: currentColor;
-	border-style: var(--wp--custom--button--border--style);
-	border-width: var(--wp--custom--button--border--width);
-	padding-top: var(--wp--custom--button--spacing--padding--top);
-	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
-	padding-left: var(--wp--custom--button--spacing--padding--left);
-	padding-right: var(--wp--custom--button--spacing--padding--right);
-}
-
-.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
-.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
-.wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
-	fill: var(--wp--custom--button--color--text);
-}
-
-.wp-block-button.is-style-outline .wp-block-button__link {
-	--wp--custom--button--color--text: var(--wp--custom--button--border--color);
-	--wp--custom--button--color--background: transparent;
-	background-color: var(--wp--custom--button--color--background);
-	border-color: currentColor;
-	border-style: var(--wp--custom--button--border--style);
-	border-width: var(--wp--custom--button--border--width);
-	color: var(--wp--custom--button--color--text);
-	padding-top: var(--wp--custom--button--spacing--padding--top);
-	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
-	padding-left: var(--wp--custom--button--spacing--padding--left);
-	padding-right: var(--wp--custom--button--spacing--padding--right);
-}
-
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
-	--wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
-	--wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
-	--wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
-	color: var(--wp--custom--button--color--text);
-	background-color: var(--wp--custom--button--color--background);
-	border-color: currentColor;
-	border-color: var(--wp--custom--button--border--color);
-}
-
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
-	fill: var(--wp--custom--button--color--text);
-}
-
-.wp-block-button.is-style-outline .wp-block-button__link svg {
-	fill: var(--wp--custom--button--color--text);
+.wp-block-buttons .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
+.wp-block-buttons .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
+.wp-block-buttons .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
+.wp-block-buttons.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
+.wp-block-buttons.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
+.wp-block-buttons.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
+	color: var(--wp--custom--button--hover--color--text);
+	background-color: var(--wp--custom--button--hover--color--background);
+	border-color: var(--wp--custom--button--hover--color--background);
 }

--- a/style.css
+++ b/style.css
@@ -16,3 +16,86 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 Twenty Twenty-Two WordPress Theme, (C) 2021 WordPress.org
 Twenty Twenty-Two is distributed under the terms of the GNU GPL.
 */
+
+/**
+ * Button
+ */
+/**
+ * Block Options
+ */
+ .wp-block-button.wp-block-button__link,
+ .wp-block-button .wp-block-button__link {
+	 border-width: 0;
+	 padding-top: calc( var(--wp--custom--button--spacing--padding--top) + var(--wp--custom--button--border--width));
+	 padding-bottom: calc( var(--wp--custom--button--spacing--padding--bottom) + var(--wp--custom--button--border--width));
+	 padding-left: calc( var(--wp--custom--button--spacing--padding--left) + var(--wp--custom--button--border--width));
+	 padding-right: calc( var(--wp--custom--button--spacing--padding--right) + var(--wp--custom--button--border--width));
+	 text-decoration: none;
+ }
+ 
+ .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
+ .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
+ .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
+ .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
+	 --wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
+	 --wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
+	 --wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
+	 opacity: 1;
+	 color: var(--wp--custom--button--color--text);
+	 background-color: var(--wp--custom--button--color--background);
+	 border-color: currentColor;
+	 border-color: var(--wp--custom--button--border--color);
+ }
+ 
+ .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
+ .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
+ .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
+ .wp-block-button .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
+	 fill: var(--wp--custom--button--color--text);
+ }
+ 
+ .wp-block-button.is-style-outline.wp-block-button__link,
+ .wp-block-button.is-style-outline .wp-block-button__link {
+	 --wp--custom--button--color--text: var(--wp--custom--button--border--color);
+	 --wp--custom--button--color--background: transparent;
+	 border-style: var(--wp--custom--button--border--style);
+	 border-width: var(--wp--custom--button--border--width);
+	 padding-top: var(--wp--custom--button--spacing--padding--top);
+	 padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
+	 padding-left: var(--wp--custom--button--spacing--padding--left);
+	 padding-right: var(--wp--custom--button--spacing--padding--right);
+	 opacity: 1;
+	 color: var(--wp--custom--button--color--text);
+	 background-color: var(--wp--custom--button--color--background);
+	 border-color: currentColor;
+ }
+ 
+ .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus,
+ .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover,
+ .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus,
+ .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus {
+	 --wp--custom--button--color--text: var(--wp--custom--button--hover--color--text);
+	 --wp--custom--button--color--background: var(--wp--custom--button--hover--color--background);
+	 --wp--custom--button--border--color: var(--wp--custom--button--hover--border--color);
+	 opacity: 1;
+	 color: var(--wp--custom--button--color--text);
+	 background-color: var(--wp--custom--button--color--background);
+	 border-color: currentColor;
+	 border-color: var(--wp--custom--button--border--color);
+ }
+ 
+ .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):hover svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color):focus svg, .wp-block-button.is-style-outline.wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg,
+ .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):hover svg,
+ .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color):focus svg,
+ .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background):not(.has-text-color).has-focus svg {
+	 fill: var(--wp--custom--button--color--text);
+ }
+ 
+ .wp-block-button.is-style-outline.wp-block-button__link svg,
+ .wp-block-button.is-style-outline .wp-block-button__link svg {
+	 fill: var(--wp--custom--button--color--text);
+ }
+ 
+ .wp-block-buttons .wp-block-button:last-child {
+	 margin-bottom: 0;
+ }

--- a/theme.json
+++ b/theme.json
@@ -105,6 +105,40 @@
 			]
 		},
 		"custom": {
+			"button": {
+				"border": {
+					"color": "var(--wp--preset--color--primary)",
+					"radius": "4px",
+					"style": "solid",
+					"width": "2px"
+				},
+				"color": {
+					"background": "var(--wp--preset--color--primary)",
+					"text": "var(--wp--preset--color--background)"
+				},
+				"hover": {
+					"color": {
+						"text": "var(--wp--preset--color--background)",
+						"background": "var(--wp--preset--color--secondary)"
+					},
+					"border": {
+						"color": "var(--wp--preset--color--secondary)"
+					}
+				},
+				"spacing": {
+					"padding": {
+						"top": "0.667em",
+						"bottom": "0.667em",
+						"left": "1.333em",
+						"right": "1.333em"
+					}
+				},
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)",
+					"fontWeight": "normal",
+					"lineHeight": 2
+				}
+			},
 			"spacing": {
 				"small": "max(1.25rem, 5vw)",
 				"medium": "clamp(2rem, 8vw, calc(4 * var(--wp--style--block-gap)))",

--- a/theme.json
+++ b/theme.json
@@ -106,37 +106,11 @@
 		},
 		"custom": {
 			"button": {
-				"border": {
-					"color": "var(--wp--preset--color--primary)",
-					"radius": "4px",
-					"style": "solid",
-					"width": "2px"
-				},
-				"color": {
-					"background": "var(--wp--preset--color--background)",
-					"text": "var(--wp--preset--color--background)"
-				},
 				"hover": {
 					"color": {
-						"text": "var(--wp--preset--color--primary)",
-						"background": "var(--wp--preset--color--background)"
-					},
-					"border": {
-						"color": "var(--wp--preset--color--primary)"
+						"text": "var(--wp--preset--color--background)",
+						"background": "var(--wp--preset--color--foreground)"
 					}
-				},
-				"spacing": {
-					"padding": {
-						"top": "0.667em",
-						"bottom": "0.667em",
-						"left": "1.333em",
-						"right": "1.333em"
-					}
-				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--normal)",
-					"fontWeight": "normal",
-					"lineHeight": 2
 				}
 			},
 			"spacing": {
@@ -228,7 +202,8 @@
 					"text": "var(--wp--preset--color--background)"
 				},
 				"typography": {
-					"fontSize": "var(--wp--preset--typography--font-size--normal)"
+					"fontSize": "var(--wp--preset--typography--font-size--normal)",
+					"fontWeight": "normal"
 				}
 			},
 			"core/post-title": {

--- a/theme.json
+++ b/theme.json
@@ -113,16 +113,16 @@
 					"width": "2px"
 				},
 				"color": {
-					"background": "var(--wp--preset--color--primary)",
+					"background": "var(--wp--preset--color--background)",
 					"text": "var(--wp--preset--color--background)"
 				},
 				"hover": {
 					"color": {
-						"text": "var(--wp--preset--color--background)",
-						"background": "var(--wp--preset--color--secondary)"
+						"text": "var(--wp--preset--color--primary)",
+						"background": "var(--wp--preset--color--background)"
 					},
 					"border": {
-						"color": "var(--wp--preset--color--secondary)"
+						"color": "var(--wp--preset--color--primary)"
 					}
 				},
 				"spacing": {

--- a/theme.json
+++ b/theme.json
@@ -202,8 +202,7 @@
 					"text": "var(--wp--preset--color--background)"
 				},
 				"typography": {
-					"fontSize": "var(--wp--preset--typography--font-size--normal)",
-					"fontWeight": "normal"
+					"fontSize": "var(--wp--preset--typography--font-size--normal)"
 				}
 			},
 			"core/post-title": {


### PR DESCRIPTION
**Description**

This PR adds a default button hover state that just changes the background color. Works for both default and outline style buttons. Falls back to no hover state if a color customizations have been made.

Alternative to #162, which is more complicated and will probably not work with the hover / active state capabilities coming later in Gutenberg. Solves #99.

**Screenshots**

https://user-images.githubusercontent.com/5375500/138921352-ea5907d4-20d6-4d7f-80d3-e29b025d4249.mp4

**Testing Instructions** 

1. Test default and outline style buttons in the editor and front-end
2. Adjust the padding on a global and block level, verify the hover states still work
3. Adjust the colors on a global and block level, verify the hover state does not work
