### PR TITLE
I18n: Allow translators to control the whole credit string in footer patterns

### DIFF
--- a/inc/patterns/footer-blog.php
+++ b/inc/patterns/footer-blog.php
@@ -43,7 +43,12 @@ return array(
 					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title /-->
 
 					<!-- wp:paragraph {"align":"right"} -->
-					<p class="has-text-align-right">' . esc_html__( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a></p>
+					<p class="has-text-align-right">' .
+					sprintf(
+						/* Translators: WordPress link. */
+						esc_html__( 'Proudly powered by %s', 'twentytwentytwo' ),
+						'<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a>'
+					) . '</p>
 					<!-- /wp:paragraph --></div>
 					<!-- /wp:group --></div>
 					<!-- /wp:group -->',

--- a/inc/patterns/footer-dark.php
+++ b/inc/patterns/footer-dark.php
@@ -11,7 +11,12 @@ return array(
 					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title /-->
 
 					<!-- wp:paragraph {"align":"right"} -->
-					<p class="has-text-align-right">' . esc_html__( 'Proudly powered by ', 'twentytwentytwo' ) . '<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a></p>
+					<p class="has-text-align-right">' .
+					sprintf(
+						/* Translators: WordPress link. */
+						esc_html__( 'Proudly powered by %s', 'twentytwentytwo' ),
+						'<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a>'
+					) . '</p>
 					<!-- /wp:paragraph --></div>
 					<!-- /wp:group --></div>
 					<!-- /wp:group -->',


### PR DESCRIPTION
In #124, few strings were changed so that they are no longer broken and instead use placeholder. This PR covers strings that were missed in #124.
