### PR TITLE
Fix typo in Footer Pattern Name

### DIFF
--- a/inc/patterns/footer-dark.php
+++ b/inc/patterns/footer-dark.php
@@ -3,7 +3,7 @@
  * Dark footer wtih title and citation
  */
 return array(
-	'title'      => __( 'Dark footer with title and citation)', 'twentytwentytwo' ),
+	'title'      => __( 'Dark footer with title and citation', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-footers' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->


### PR DESCRIPTION
Fixes #185 

**Description**

The following translatable string contains a closing bracket, as reported in #185:

https://github.com/WordPress/twentytwentytwo/blob/fca5cfd7085a44db22eeb6dd1aeeb922abd563f1/inc/patterns/footer-dark.php#L6

**Screenshots**

As the problem affects a translatable string, a screenshot is not applicable in this case.

**Testing Instructions** 

1. Look up the changed file.
2. Note that `'Dark footer with title and citation)'` had been corrected to `'Dark footer with title and citation'`.
