### PR TITLE
Remove dropCap support

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -169,6 +169,7 @@
 			]
 		},
 		"typography": {
+			"dropCap": false,
 			"customLineHeight": true,
 			"fontFamilies": [
 				{


### PR DESCRIPTION
Fixes #180

**Description**

As reported in #180, using drop caps can lead to a size/spacing problem. This PR removes the support for drop caps to prevent this problem.

**Screenshots**

<table>
<tr>
<td>Before:
<br><br>

![#180-before](https://user-images.githubusercontent.com/3323310/139525978-8cfb3350-e2aa-4a97-9ae7-6005a7a87e5f.png)
</td>
<td>After:
<br><br>

![#180-after](https://user-images.githubusercontent.com/3323310/139525975-b855db8f-1f7a-49de-b5a0-4b7260aef0cf.png)
</td>
</tr>
</table>

**Testing Instructions** 

1. Create a test page with a paragraph and activate the drop cap option.
2. Check out this PR.
3. Create another test page with a paragraph to verify that the drop cap option is no longer visible.
