### PR TITLE
Change Post Comments to Query Comments

### DIFF
--- a/block-template-parts/comments.html
+++ b/block-template-parts/comments.html
@@ -1,0 +1,9 @@
+<!-- wp:comments-query-loop -->
+<div class="wp-block-comments-query-loop"><!-- wp:comment-template -->
+	<!-- wp:post-comment-author {"isLink":true} /-->
+	<!-- wp:post-comment-date {"format":"F j, Y g:i a","isLink":true,"fontSize":"small"} /-->
+	<!-- wp:post-comment-content /-->
+
+	<!-- /wp:comment-template -->
+</div>
+<!-- /wp:comments-query-loop -->

--- a/block-templates/page-no-separators.html
+++ b/block-templates/page-no-separators.html
@@ -11,7 +11,7 @@
 
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
-<!-- wp:post-comments {"style":{"spacing":{"padding":{"top":"var(--wp--custom--spacing--medium, 6rem)"}}}} /--></div>
+<!-- wp:template-part {"slug":"comments","style":{"spacing":{"padding":{"top":"var(--wp--custom--spacing--medium, 6rem)"}}}} /--></div>
 <!-- /wp:group --></main>
 <!-- /wp:group -->
 

--- a/block-templates/page.html
+++ b/block-templates/page.html
@@ -15,7 +15,7 @@
 <div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
+<!-- wp:template-part {"slug":"comments"} /-->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">

--- a/block-templates/single-no-separators.html
+++ b/block-templates/single-no-separators.html
@@ -28,7 +28,9 @@
 <div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:post-comments /--></div>
+<!-- wp:template-part {"slug":"comments"} /-->
+
+</div>
 <!-- /wp:group --></main>
 <!-- /wp:group -->
 

--- a/block-templates/single.html
+++ b/block-templates/single.html
@@ -40,7 +40,9 @@
 <hr class="wp-block-separator is-style-wide"/>
 <!-- /wp:separator -->
 
-<!-- wp:post-comments /--></div>
+<!-- wp:template-part {"slug":"comments"} /-->
+
+</div>
 <!-- /wp:group --></main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
**Description**

Post Comments isn't shipping in 5.9 so trying Query Comments instead as proposed in https://github.com/WordPress/twentytwentytwo/issues/179

**Screenshots**
<img width="816" alt="Screenshot 2021-11-01 at 17 46 10" src="https://user-images.githubusercontent.com/275961/139716318-6ae06405-e3e5-4e5b-8c58-40a8292c5aed.png">

**Testing Instructions** 

1. Open a post/page with comments and see what they look like
