### PR TITLE
Tidies up functions.php to aid readability

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -12,16 +12,16 @@
 
 if ( ! function_exists( 'twentytwentytwo_support' ) ) :
 
-	/** 
+	/**
 	 * Add support for core block visual styles.
 	 * Styles load in both the editor and the front end.
-	 * 
+	 *
 	 * @link https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-support/#default-block-styles
-	 * 
+	 *
 	 * @return void
 	 */
 	function twentytwentytwo_support() {
-		
+
 		add_theme_support( 'wp-block-styles' );
 
 	}
@@ -34,7 +34,7 @@ if ( ! function_exists( 'twentytwentytwo_styles' ) ) :
 
 	/**
 	 * Enqueue styles.
-	 * 
+	 *
 	 * @return void
 	 */
 	function twentytwentytwo_styles() {
@@ -47,7 +47,7 @@ if ( ! function_exists( 'twentytwentytwo_styles' ) ) :
 
 		// Add metadata to the CSS stylesheet.
 		wp_style_add_data( 'twentytwentytwo-style', 'path', get_template_directory() . '/style.css' );
-		
+
 		// Enqueue theme stylesheet.
 		wp_enqueue_style( 'twentytwentytwo-style' );
 
@@ -61,7 +61,7 @@ if ( ! function_exists( 'twentytwentytwo_editor_styles' ) ) :
 
 	/**
 	 * Enqueue editor styles.
-	 * 
+	 *
 	 * @return void
 	 */
 	function twentytwentytwo_editor_styles() {
@@ -80,7 +80,7 @@ if ( ! function_exists( 'twentytwentytwo_get_font_face_styles' ) ) :
 	/**
 	 * Get font face styles.
 	 * Called by functions twentytwentytwo_styles() and twentytwentytwo_editor_styles() above.
-	 * 
+	 *
 	 * @return string
 	 */
 	function twentytwentytwo_get_font_face_styles() {

--- a/functions.php
+++ b/functions.php
@@ -1,46 +1,90 @@
 <?php
+/**
+ * Twenty Twenty-Two functions and definitions
+ *
+ * @link https://developer.wordpress.org/themes/basics/theme-functions/
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty_Two
+ * @since 1.0.0
+ */
+
 
 if ( ! function_exists( 'twentytwentytwo_support' ) ) :
+
+	/** 
+	 * Add support for core block visual styles.
+	 * Styles load in both the editor and the front end.
+	 * 
+	 * @link https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-support/#default-block-styles
+	 * 
+	 * @return void
+	 */
 	function twentytwentytwo_support() {
-		// Adding support for core block visual styles.
+		
 		add_theme_support( 'wp-block-styles' );
+
 	}
 	add_action( 'after_setup_theme', 'twentytwentytwo_support' );
+
 endif;
+
 
 if ( ! function_exists( 'twentytwentytwo_styles' ) ) :
+
 	/**
-	 * Enqueue scripts and styles.
+	 * Enqueue styles.
+	 * 
+	 * @return void
 	 */
 	function twentytwentytwo_styles() {
+
 		// Register theme stylesheet.
 		wp_register_style( 'twentytwentytwo-style', '' );
+
 		// Add styles inline.
 		wp_add_inline_style( 'twentytwentytwo-style', twentytwentytwo_get_font_face_styles() );
-		// Enqueue theme stylesheet.
+
+		// Add metadata to the CSS stylesheet.
 		wp_style_add_data( 'twentytwentytwo-style', 'path', get_template_directory() . '/style.css' );
+		
+		// Enqueue theme stylesheet.
 		wp_enqueue_style( 'twentytwentytwo-style' );
+
 	}
 	add_action( 'wp_enqueue_scripts', 'twentytwentytwo_styles' );
+
 endif;
+
 
 if ( ! function_exists( 'twentytwentytwo_editor_styles' ) ) :
+
 	/**
 	 * Enqueue editor styles.
+	 * 
+	 * @return void
 	 */
 	function twentytwentytwo_editor_styles() {
+
+		// Add styles inline.
 		wp_add_inline_style( 'wp-block-library', twentytwentytwo_get_font_face_styles() );
+
 	}
 	add_action( 'admin_init', 'twentytwentytwo_editor_styles' );
+
 endif;
 
+
 if ( ! function_exists( 'twentytwentytwo_get_font_face_styles' ) ) :
+
 	/**
 	 * Get font face styles.
-	 *
+	 * Called by functions twentytwentytwo_styles() and twentytwentytwo_editor_styles() above.
+	 * 
 	 * @return string
 	 */
 	function twentytwentytwo_get_font_face_styles() {
+
 		return "
 		@font-face{
 			font-family: 'Source Serif Pro';
@@ -58,8 +102,11 @@ if ( ! function_exists( 'twentytwentytwo_get_font_face_styles' ) ) :
 			src: url('" . get_theme_file_uri( 'assets/fonts/SourceSerif4Variable-Italic.ttf.woff2' ) . "') format('woff2');
 		}
 		";
+
 	}
+
 endif;
+
 
 // Add block patterns
 require get_template_directory() . '/inc/block-patterns.php';


### PR DESCRIPTION
**Description**

Cleans up` functions.php` to so that it's easier to read and adds some extra space and file/function headers.

As per [#191 ](https://github.com/WordPress/twentytwentytwo/issues/191).

**Screenshots**

N/A

**Testing Instructions** 

N/A Only line spacing and comment blocks added