### PR TITLE
[Pattern] Update Footer with query, title, and citation

### DIFF
--- a/inc/patterns/footer-query-title-citation.php
+++ b/inc/patterns/footer-query-title-citation.php
@@ -13,7 +13,7 @@ return array(
 
 					<!-- wp:post-excerpt /-->
 
-					<!-- wp:post-date /-->
+					<!-- wp:post-date {"isLink":true} /-->
 					<!-- /wp:post-template --></div>
 					<!-- /wp:query -->
 
@@ -23,15 +23,17 @@ return array(
 
 					<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title /-->
-
-					<!-- wp:paragraph {"align":"right"} -->
-					<p class="has-text-align-right">' .
+					<!-- wp:group {"layout":{"type":"flex","justifyContent":"right"}} -->
+					<div class="wp-block-group">
+					<!-- wp:paragraph -->
+					<p>' .
 					sprintf(
 						/* Translators: WordPress link. */
 						esc_html__( 'Proudly powered by %s', 'twentytwentytwo' ),
 						'<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a>'
 					) . '</p>
 					<!-- /wp:paragraph --></div>
+					<!-- /wp:group --></div>
 					<!-- /wp:group --></div>
 					<!-- /wp:group -->',
 );


### PR DESCRIPTION
**Description**
Partial for https://github.com/WordPress/twentytwentytwo/issues/91
Solves the alignment of the powered by text on small screens.
It does this by removing the right alignment from the paragraph, and adding a second row block.

On larger screen sizes, the texts are still aligned to the left and right respectively thanks to the space-between justification.

It also solves an issue I noticed from the screenshot below; when a post has no title, the post could not be reached.
To solve that I enabled the link option on the post date block.

**Screenshots**
![The footer text is aligned vertically](https://user-images.githubusercontent.com/7422055/140041062-97fbe5b5-e36a-483e-92dd-29fb7ee3cc20.png)

![Animation showing how the footer text position changes depending on screen width](https://user-images.githubusercontent.com/7422055/140042567-0ce90066-bcac-499d-bdfa-328e38410659.gif)


**Testing Instructions** 
1. Add the "Footer with query, title, and citation" block pattern in the site editor. 
2. View the mobile preview, and view the front on different screen sizes.
