### PR TITLE
[Pattern] Update Footer with query, featured images, title, and citation

### DIFF
--- a/inc/patterns/footer-query-images-title-citation.php
+++ b/inc/patterns/footer-query-images-title-citation.php
@@ -25,15 +25,17 @@ return array(
 
 					<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title /-->
-
-					<!-- wp:paragraph {"align":"right"} -->
-					<p class="has-text-align-right">' .
+					<!-- wp:group {"layout":{"type":"flex","justifyContent":"right"}} -->
+					<div class="wp-block-group">
+					<!-- wp:paragraph -->
+					<p>' .
 					sprintf(
 						/* Translators: WordPress link. */
 						esc_html__( 'Proudly powered by %s', 'twentytwentytwo' ),
 						'<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentytwo' ) ) . '" rel="nofollow">WordPress</a>'
 					) . '</p>
 					<!-- /wp:paragraph --></div>
+					<!-- /wp:group --></div>
 					<!-- /wp:group --></div>
 					<!-- /wp:group -->',
 );


### PR DESCRIPTION
**Description**
Partial for https://github.com/WordPress/twentytwentytwo/issues/91

Solves the alignment of the powered by text on small screens.
It does this by removing the right alignment from the paragraph, and adding a second row block.

**Screenshots**
![The footer text is aligned vertically](https://user-images.githubusercontent.com/7422055/140043840-8eebec42-8f8e-47e9-876a-cc5395f60073.png)


**Testing Instructions** 
1. Add the "Footer with query, title, and citation" block pattern in the site editor.
2. View the mobile preview, and view the front on different screen sizes.
