### PR TITLE
Try styling Search and File buttons

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -45,6 +45,9 @@ if ( ! function_exists( 'twentytwentytwo_styles' ) ) :
 		// Add styles inline.
 		wp_add_inline_style( 'twentytwentytwo-style', twentytwentytwo_get_font_face_styles() );
 
+		// Add global styles linked variables.
+		wp_add_inline_style( 'twentytwentytwo-style', twentytwentytwo_theme_variables() );
+
 		// Add metadata to the CSS stylesheet.
 		wp_style_add_data( 'twentytwentytwo-style', 'path', get_template_directory() . '/style.css' );
 
@@ -56,6 +59,22 @@ if ( ! function_exists( 'twentytwentytwo_styles' ) ) :
 
 endif;
 
+/**
+ * Create variables linked to global styles.
+ *
+ * @return string
+ */
+function twentytwentytwo_theme_variables() {
+	if ( ! function_exists( 'gutenberg_get_global_styles' ) ) {
+		return;
+	}
+
+	// Get the properties of the button that we want to use in other blocks like search and file.
+	$button_styles = gutenberg_get_global_styles( array(), 'core/button' );
+
+	// Create variables that point to the value of those customizable properties.
+	return ':root, body { --wp--theme--button--color--text: ' . $button_styles['color']['text'] . '; --wp--theme--button--color--background: ' . $button_styles['color']['background'] . '; --wp--theme--button--border--radius: ' . $button_styles['border']['radius'] . '; }';
+}
 
 if ( ! function_exists( 'twentytwentytwo_editor_styles' ) ) :
 
@@ -68,6 +87,12 @@ if ( ! function_exists( 'twentytwentytwo_editor_styles' ) ) :
 
 		// Add styles inline.
 		wp_add_inline_style( 'wp-block-library', twentytwentytwo_get_font_face_styles() );
+
+		// Add global styles linked variables.
+		wp_add_inline_style( 'wp-block-library', twentytwentytwo_theme_variables() );
+
+		// Add stylesheet.
+		add_editor_style( array( get_stylesheet_uri() ) );
 
 	}
 	add_action( 'admin_init', 'twentytwentytwo_editor_styles' );

--- a/style.css
+++ b/style.css
@@ -18,7 +18,7 @@ Twenty Twenty-Two is distributed under the terms of the GNU GPL.
 */
 
 .wp-block-search__button,
-.wp-block-file a.wp-block-file__button {
+.wp-block-file .wp-block-file__button {
 	background-color: var(--wp--theme--button--color--background);
 	border: none;
 	border-radius: var(--wp--theme--button--border--radius);

--- a/style.css
+++ b/style.css
@@ -16,3 +16,12 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
 Twenty Twenty-Two WordPress Theme, (C) 2021 WordPress.org
 Twenty Twenty-Two is distributed under the terms of the GNU GPL.
 */
+
+.wp-block-search__button,
+.wp-block-file a.wp-block-file__button {
+	background-color: var(--wp--theme--button--color--background);
+	border: none;
+	border-radius: var(--wp--theme--button--border--radius);
+	color: var(--wp--theme--button--color--text);
+	cursor: pointer;
+}


### PR DESCRIPTION
**Description**

This PR tries to style the Search and File blocks' buttons.

Since there is not yet a way to style those blocks via theme.json / global styles, the PR links the relevant styles to the Button block's using [this idea](https://github.com/WordPress/gutenberg/pull/36130#issuecomment-957360547). 

Attempts to solve #101 and #11.

**Screenshots**

Before | After
------- | ------
<img width="753" alt="Screen Shot 2021-11-03 at 11 09 02 AM" src="https://user-images.githubusercontent.com/5375500/140087322-bdefe64d-87ac-458e-8fc6-9d9368db32fd.png"> | <img width="711" alt="Screen Shot 2021-11-03 at 11 08 55 AM" src="https://user-images.githubusercontent.com/5375500/140087341-7309a8db-065e-4690-873e-98df3512c0fc.png">

**Testing Instructions** 

1. Create a post and add this markup: https://gist.github.com/jffng/263436360988105ab73c35effd494fe0 
3. Verify the colors and border match the Button block's in the editor and front-end
4. Go to the site editor global styles panel and customize the button block's colors. Select a _non-palette_ color*
5. Verify the colors have changed in the post

Note that this currently breaks if you select a preset color because of the value of the variable is not valid CSS, so we'd have to parse / transform it in the theme. This is what ends up getting output when you select a preset (see the background color):

<img width="360" alt="Screen Shot 2021-11-03 at 11 13 39 AM" src="https://user-images.githubusercontent.com/5375500/140088166-c445b52a-8717-4303-a9cd-c978d3beadd9.png">