### PR TITLE
Adds support for block borders to theme.json

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -215,6 +215,12 @@
 		"layout": {
 			"contentSize": "650px",
 			"wideSize": "1000px"
+		},
+		"border": {
+			"customColor": true,
+			"customRadius": true,
+			"customStyle": true,
+			"customWidth": true
 		}
 	},
 	"styles": {


### PR DESCRIPTION
**Description**

Adds support for block borders to `theme.json`, as per #198 

**Screenshots**

Radius appears for e.g. button and image blocks:

![image](https://user-images.githubusercontent.com/20643925/140114319-ca5ee88a-f307-4d62-90ee-622fe0753192.png)

All options (width, style, colour and radius),  appear for e.g. group block: 

![image](https://user-images.githubusercontent.com/20643925/140115927-66f9df6a-98f5-4132-a059-8a8ae78fb460.png)

**Testing Instructions** 

1. Add an image block
2. Check that border radius option appears in sidebar
3. Add a group block
4. Check that all border options (width, style, colour and radius) appear in sidebar

_See [this page](https://fullsiteediting.com/lessons/theme-json-color-options/#h-which-wordpress-blocks-support-borders) for which blocks support which border attributes._