### PR TITLE
Don't inline style.css, but enqueue it.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -40,13 +40,15 @@ if ( ! function_exists( 'twentytwentytwo_styles' ) ) :
 	function twentytwentytwo_styles() {
 
 		// Register theme stylesheet.
-		wp_register_style( 'twentytwentytwo-style', '' );
+		wp_register_style(
+			'twentytwentytwo-style',
+			get_template_directory_uri() . '/style.css',
+			array(),
+			wp_get_theme()->get( 'Version' ),
+		);
 
 		// Add styles inline.
 		wp_add_inline_style( 'twentytwentytwo-style', twentytwentytwo_get_font_face_styles() );
-
-		// Add metadata to the CSS stylesheet.
-		wp_style_add_data( 'twentytwentytwo-style', 'path', get_template_directory() . '/style.css' );
 
 		// Enqueue theme stylesheet.
 		wp_enqueue_style( 'twentytwentytwo-style' );


### PR DESCRIPTION
**Description**
Register and enqueue style.css without printing it inline.

Right now, the style.css file isn't actually used, it is empty. It was enqueued this way to allow adding CSS to the front,
for https://github.com/WordPress/twentytwentytwo/issues/206 and any other CSS _we are not sure will be solved by theme.json in time._

**Testing Instructions** 
1. View source.
2. Confirm that the style.css file header is not printed in the source.
