### PR TITLE
Don't inline style.css, and don't enqueue it.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -45,9 +45,6 @@ if ( ! function_exists( 'twentytwentytwo_styles' ) ) :
 		// Add styles inline.
 		wp_add_inline_style( 'twentytwentytwo-style', twentytwentytwo_get_font_face_styles() );
 
-		// Add metadata to the CSS stylesheet.
-		wp_style_add_data( 'twentytwentytwo-style', 'path', get_template_directory() . '/style.css' );
-
 		// Enqueue theme stylesheet.
 		wp_enqueue_style( 'twentytwentytwo-style' );
 


### PR DESCRIPTION
**Description**
Alternative to https://github.com/WordPress/twentytwentytwo/pull/207

**Testing Instructions** 

_Provide steps for testing_
1. View source.
2. Confirm that the style.css file header is not printed in the source.
3. Confirm that the font family still works correctly, this should still be inline:

```
<style id='twentytwentytwo-style-inline-css'>

		@font-face{
			font-family: 'Source Serif Pro';
			font-weight: 200 900;
			font-style: normal;
			font-stretch: normal;
			src: url('http://localhost:8888/wp-content/themes/twentytwentytwo/assets/fonts/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');
		}

		@font-face{
			font-family: 'Source Serif Pro';
			font-weight: 200 900;
			font-style: italic;
			font-stretch: normal;
			src: url('http://localhost:8888/wp-content/themes/twentytwentytwo/assets/fonts/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');
		}
		
</style>
```