### PR TITLE
Make "ABOUT US" use the Gutenberg text case setting

### DIFF
--- a/inc/patterns/footer-about-title-logo.php
+++ b/inc/patterns/footer-about-title-logo.php
@@ -9,8 +9,8 @@ return array(
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"8rem","bottom":"6rem"}}},"backgroundColor":"secondary","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-secondary-background-color has-background" style="padding-top:8rem;padding-bottom:6rem"><!-- wp:columns {"align":"wide"} -->
 					<div class="wp-block-columns alignwide"><!-- wp:column {"width":"33%"} -->
-					<div class="wp-block-column" style="flex-basis:33%"><!-- wp:paragraph -->
-					<p>' . esc_html__( 'ABOUT US', 'twentytwentytwo' ) . '</p>
+					<div class="wp-block-column" style="flex-basis:33%"><!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}}} -->
+					<p style="text-transform:uppercase">' . esc_html__( 'About us', 'twentytwentytwo' ) . '</p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:paragraph {"style":{"fontSize":"small"} -->

--- a/inc/patterns/footer-blog.php
+++ b/inc/patterns/footer-blog.php
@@ -19,8 +19,8 @@ return array(
 					<!-- /wp:column -->
 
 					<!-- wp:column -->
-					<div class="wp-block-column"><!-- wp:paragraph -->
-					<p>' . esc_html__( 'LATEST POSTS', 'twentytwentytwo' ) . '</p>
+					<div class="wp-block-column"><!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}}} -->
+					<p style="text-transform:uppercase">' . esc_html__( 'LATEST POSTS', 'twentytwentytwo' ) . '</p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:latest-posts /--></div>

--- a/inc/patterns/general-featured-posts.php
+++ b/inc/patterns/general-featured-posts.php
@@ -6,8 +6,8 @@ return array(
 	'title'      => __( 'Featured posts', 'twentytwentytwo' ),
 	'categories' => array( 'twentytwentytwo-general' ),
 	'content'    => '<!-- wp:group {"align":"wide","layout":{"inherit":false}} -->
-					<div class="wp-block-group alignwide"><!-- wp:paragraph -->
-					<p>' . esc_html__( 'LATEST POSTS', 'twentytwentytwo' ) . '</p>
+					<div class="wp-block-group alignwide"><!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}}} -->
+					<p style="text-transform:uppercase">' . esc_html__( 'LATEST POSTS', 'twentytwentytwo' ) . '</p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":3}} -->


### PR DESCRIPTION
Addresses an issue raised in https://github.com/WordPress/wordpress-develop/pull/1817#discussion_r745039417.

I'd like to keep this uppercase for text hierarchy reasons, but we'll switch to using the Gutenberg text case control. 

If that is a problem for other languages, presumably Gutenberg should be able to handle that elegantly itself (Otherwise this setting is problematic for all themes). 