### PR TITLE
Resovle PHPCS warnings

### DIFF
--- a/inc/patterns/hidden-404.php
+++ b/inc/patterns/hidden-404.php
@@ -3,9 +3,9 @@
  * 404 content.
  */
 return array(
-	'title'      => __( '404 content', 'twentytwentytwo' ),
-	'inserter'   => false,
-	'content'    => '<!-- wp:heading {"style":{"typography":{"fontSize":"clamp(4rem, 40vw, 20rem)","fontWeight":"200","lineHeight":"1"}},"className":"has-text-align-center"} -->
+	'title'    => __( '404 content', 'twentytwentytwo' ),
+	'inserter' => false,
+	'content'  => '<!-- wp:heading {"style":{"typography":{"fontSize":"clamp(4rem, 40vw, 20rem)","fontWeight":"200","lineHeight":"1"}},"className":"has-text-align-center"} -->
 					<h2 class="has-text-align-center" style="font-size:clamp(4rem, 40vw, 20rem);font-weight:200;line-height:1">' . esc_html( _x( '404', 'Error code for a webpage that is not found.', 'twentytwentytwo' ) ) . '</h2>
 					<!-- /wp:heading -->
 					<!-- wp:paragraph {"align":"center"} -->

--- a/inc/patterns/hidden-heading-and-bird.php
+++ b/inc/patterns/hidden-heading-and-bird.php
@@ -7,9 +7,9 @@
  * not appear in the inserter.
  */
 return array(
-	'title'      => __( 'Heading and bird image', 'twentytwentytwo' ),
-	'inserter'   => false,
-	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","top":"0px","bottom":"0px"}}},"layout":{"inherit":true}} -->
+	'title'    => __( 'Heading and bird image', 'twentytwentytwo' ),
+	'inserter' => false,
+	'content'  => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","top":"0px","bottom":"0px"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-top:0px;padding-right:max(1.25rem, 5vw);padding-bottom:0px;padding-left:max(1.25rem, 5vw)"><!-- wp:heading {"align":"wide","style":{"typography":{"fontSize":"clamp(4rem, 8vw, 6.25rem)","lineHeight":"1.15"}}} -->
 					<h2 class="alignwide" style="font-size:clamp(4rem, 8vw, 6.25rem);line-height:1.15">' . wp_kses_post( __( '<em>The Hatchery</em>: a blog about my adventures in bird watching', 'twentytwentytwo' ) ) . '</h2>
 					<!-- /wp:heading --></div>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -26,7 +26,7 @@
 	<file>.</file>
 
 	<rule ref="WordPress-Core"/>
-	<rule ref="WordPress.CodeAnalysis.EmptyStatement"/>
+	<rule ref="Generic.CodeAnalysis.EmptyPHPStatement"/>
 
 	<!-- These rules are being set as warnings instead of errors, so we can error check the entire codebase. -->
 	<rule ref="WordPress.PHP.YodaConditions.NotYoda">

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -26,7 +26,7 @@
 	<file>.</file>
 
 	<rule ref="WordPress-Core"/>
-	<rule ref="Generic.CodeAnalysis.EmptyPHPStatement"/>
+	<rule ref="WordPress.CodeAnalysis.EmptyStatement"/>
 
 	<!-- These rules are being set as warnings instead of errors, so we can error check the entire codebase. -->
 	<rule ref="WordPress.PHP.YodaConditions.NotYoda">


### PR DESCRIPTION
**Description**

To resolve PHPCS warnings in the theme so they pass coding standards.

```bash
........W.W.....W 17 / 17 (100%)



FILE: inc/patterns/hidden-404.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 3 WARNINGS AFFECTING 3 LINES
----------------------------------------------------------------------
 6 | WARNING | [x] Array double arrow not aligned correctly; expected
   |         |     4 space(s) between "'title'" and double arrow, but
   |         |     found 6.
   |         |     (WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned)
 7 | WARNING | [x] Array double arrow not aligned correctly; expected
   |         |     1 space(s) between "'inserter'" and double arrow,
   |         |     but found 3.
   |         |     (WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned)
 8 | WARNING | [x] Array double arrow not aligned correctly; expected
   |         |     2 space(s) between "'content'" and double arrow,
   |         |     but found 4.
   |         |     (WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned)
----------------------------------------------------------------------
PHPCBF CAN FIX THE 3 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------


FILE: inc/patterns/hidden-heading-and-bird.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 3 WARNINGS AFFECTING 3 LINES
----------------------------------------------------------------------
 10 | WARNING | [x] Array double arrow not aligned correctly;
    |         |     expected 4 space(s) between "'title'" and double
    |         |     arrow, but found 6.
    |         |     (WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned)
 11 | WARNING | [x] Array double arrow not aligned correctly;
    |         |     expected 1 space(s) between "'inserter'" and
    |         |     double arrow, but found 3.
    |         |     (WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned)
 12 | WARNING | [x] Array double arrow not aligned correctly;
    |         |     expected 2 space(s) between "'content'" and
    |         |     double arrow, but found 4.
    |         |     (WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned)
----------------------------------------------------------------------
PHPCBF CAN FIX THE 3 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------


FILE: index.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
----------------------------------------------------------------------
 1 | WARNING | No PHP code was found in this file and short open tags
   |         | are not allowed by this install of PHP. This file may
   |         | be using short open tags but PHP does not allow
   |         | them. (Internal.NoCodeFound)
----------------------------------------------------------------------

Time: 146ms; Memory: 8MB
```

**Testing Instructions** 

1. Checkout the code in this PR. 
2. Run PHPCS `composer standards:check`.
3. See the tests now pass without errors or warnings.

![image](https://user-images.githubusercontent.com/5321364/140956615-44332bea-dad9-4d68-b747-18ec94e957ff.png)
 
