### PR TITLE
Preload main web font to improve LCP performance

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -119,5 +119,27 @@ if ( ! function_exists( 'twentytwentytwo_get_font_face_styles' ) ) :
 
 endif;
 
+if ( ! function_exists( 'twentytwentytwo_preload_webfonts' ) ) :
+
+	/**
+	 * Preloads the main web font to improve performance.
+	 *
+	 * Only the main web font (font-style: normal) is preloaded here since that font is always relevant (e.g. it used
+	 * on every heading). The other font is only needed if there is any applicable content in italic style, and
+	 * therefore preloading it would in most cases regress performance when that font would otherwise not be loaded at
+	 * all.
+	 *
+	 * @since Twenty Twenty-Two 1.0
+	 */
+	function twentytwentytwo_preload_webfonts() {
+		?>
+		<link rel="preload" href="<?php echo esc_url( get_theme_file_uri( 'assets/fonts/SourceSerif4Variable-Roman.ttf.woff2' ) ); ?>" as="font" type="font/woff2" crossorigin>
+		<?php
+	}
+
+endif;
+
+add_action( 'wp_head', 'twentytwentytwo_preload_webfonts' );
+
 // Add block patterns
 require get_template_directory() . '/inc/block-patterns.php';

--- a/functions.php
+++ b/functions.php
@@ -132,7 +132,7 @@ if ( ! function_exists( 'twentytwentytwo_preload_webfonts' ) ) :
 	 * all.
 	 *
 	 * @since Twenty Twenty-Two 1.0
-	 * 
+	 *
 	 * @return void
 	 */
 	function twentytwentytwo_preload_webfonts() {

--- a/functions.php
+++ b/functions.php
@@ -103,6 +103,7 @@ if ( ! function_exists( 'twentytwentytwo_get_font_face_styles' ) ) :
 			font-weight: 200 900;
 			font-style: normal;
 			font-stretch: normal;
+			font-display: swap;
 			src: url('" . get_theme_file_uri( 'assets/fonts/SourceSerif4Variable-Roman.ttf.woff2' ) . "') format('woff2');
 		}
 
@@ -111,6 +112,7 @@ if ( ! function_exists( 'twentytwentytwo_get_font_face_styles' ) ) :
 			font-weight: 200 900;
 			font-style: italic;
 			font-stretch: normal;
+			font-display: swap;
 			src: url('" . get_theme_file_uri( 'assets/fonts/SourceSerif4Variable-Italic.ttf.woff2' ) . "') format('woff2');
 		}
 		";

--- a/functions.php
+++ b/functions.php
@@ -132,6 +132,8 @@ if ( ! function_exists( 'twentytwentytwo_preload_webfonts' ) ) :
 	 * all.
 	 *
 	 * @since Twenty Twenty-Two 1.0
+	 * 
+	 * @return void
 	 */
 	function twentytwentytwo_preload_webfonts() {
 		?>


### PR DESCRIPTION
**Description**

This PR improves LCP performance of Twenty Twenty-Two by ~10% by preloading the main web font used. See #239 for more explanation and full before/after performance test results.

It introduces a `twentytwentytwo_preload_webfonts()` function to render the `preload` tag for the font on `wp_head`.

Fixes #239.