### PR TITLE
Try adding a home.html template back in

### DIFF
--- a/block-templates/home.html
+++ b/block-templates/home.html
@@ -1,0 +1,13 @@
+<!-- wp:template-part {"slug":"header-large-dark","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"var(--wp--custom--spacing--small, 1.25rem)","left":"var(--wp--custom--spacing--small, 1.25rem)"}}},"layout":{"inherit":true}} -->
+<main class="wp-block-group" style="padding-right:var(--wp--custom--spacing--small, 1.25rem);padding-left:var(--wp--custom--spacing--small, 1.25rem)"><!-- wp:pattern {"slug":"twentytwentytwo/general-featured-posts"} /-->
+
+<!-- wp:spacer {"height":64} -->
+<div style="height:64px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+	
+<!-- wp:pattern {"slug":"twentytwentytwo/general-subscribe"} /--></main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer","style":{"spacing":{"padding":{"top":"var(--wp--custom--spacing--large, 8rem)","right":"var(--wp--custom--spacing--small, 1.25rem)","left":"var(--wp--custom--spacing--small, 1.25rem)"}}},"layout":{"inherit":true}} /-->

--- a/block-templates/page-home.html
+++ b/block-templates/page-home.html
@@ -1,9 +1,0 @@
-<!-- wp:template-part {"slug":"header-large-dark","tagName":"header"} /-->
-
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"var(--wp--custom--spacing--small, 1.25rem)","left":"var(--wp--custom--spacing--small, 1.25rem)"}}}} -->
-<main class="wp-block-group" style="padding-right:var(--wp--custom--spacing--small, 1.25rem);padding-left:var(--wp--custom--spacing--small, 1.25rem)">
-<!-- wp:post-content {"layout":{"inherit":true}} /-->
-</main>
-<!-- /wp:group -->
-
-<!-- wp:template-part {"slug":"footer","tagName":"footer","style":{"spacing":{"padding":{"top":"var(--wp--custom--spacing--large, 8rem)","right":"var(--wp--custom--spacing--small, 1.25rem)","left":"var(--wp--custom--spacing--small, 1.25rem)"}}},"layout":{"inherit":true}} /-->


### PR DESCRIPTION
A month or so ago, we had a `home.html` template bundled with the theme. [This was removed](https://github.com/WordPress/twentytwentytwo/issues/60) since its use of a Post Content block caused confusion and brought things out of sync with the static homepage setting. 

Unfortunately, removing the `home.html` template also increased the need for [a solution for starter content](https://github.com/WordPress/twentytwentytwo/issues/116). Today if you install the theme fresh, you're greeted by these underwhelming views: 

Site Editor|Front End
---|---
![image](https://user-images.githubusercontent.com/1202812/142007584-ea5e824b-f1c4-4e4f-bcf2-18b33af32a74.png)|![image (1)](https://user-images.githubusercontent.com/1202812/142007565-22f84a9a-320d-40b8-9ffb-2e00dee7cba8.png)

We can fix this by implementing `home.html` in a slightly different way. If we consider it as "The homepage of the blog", and don't include a Post Content block, then it should work as expected. 

Site Editor|Front End
---|---
![Screen Shot 2021-11-16 at 09 58 17](https://user-images.githubusercontent.com/1202812/142009166-025313ee-1d6d-4cd1-99ef-ee6aaae10916.png)|![Screen Shot 2021-11-16 at 09 57 33](https://user-images.githubusercontent.com/1202812/142009168-d77b58f1-1951-4667-8203-07209994f4a2.png)

This provides a far better first experience for users (Enough that I think we could close #116 if this lands). It also works just fine alongside the Static Homepage setting in Settings > Reading.

The only feature that I think blocks this is that **we can't generate + include a link to view all posts on a traditional "blog" page**. Users can edit the Query block on this `home.html` template to show more than 3 posts, but it doesn't make sense to include pagination because they'll have to scroll past the large header to access every subsequent page. And there's no concept of an independent "Blog" page without a static homepage being set. Any ideas would be appreciated. 🤔 