### PR TITLE
Update padding on subscribe pattern

### DIFF
--- a/inc/patterns/general-subscribe.php
+++ b/inc/patterns/general-subscribe.php
@@ -18,8 +18,8 @@ return array(
 					<!-- /wp:buttons --></div>
 					<!-- /wp:column -->
 
-					<!-- wp:column {"verticalAlignment":"center"} -->
-					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:separator {"color":"primary","className":"is-style-wide"} -->
+					<!-- wp:column {"verticalAlignment":"center","style":{"spacing":{"padding":{"top":"2rem","bottom":"2rem"}}}} -->
+					<div class="wp-block-column is-vertically-aligned-center" style="padding-top:2rem;padding-bottom:2rem"><!-- wp:separator {"color":"primary","className":"is-style-wide"} -->
 					<hr class="wp-block-separator has-text-color has-background has-primary-background-color has-primary-color is-style-wide"/>
 					<!-- /wp:separator --></div>
 					<!-- /wp:column --></div>


### PR DESCRIPTION
This PR updates the padding on the right side of the Subscribe pattern, so that the separator block is more comfortably spaced away from the Button on small screens. It has no effect on the display at larger screen sizes. 

Before|After
---|---
<img width="375" alt="Screen Shot 2021-11-16 at 4 05 12 PM" src="https://user-images.githubusercontent.com/1202812/142065867-a7c57913-61e2-4409-9f43-bc8ef694acda.png">|<img width="374" alt="Screen Shot 2021-11-16 at 4 05 24 PM" src="https://user-images.githubusercontent.com/1202812/142065817-03aef5be-d6fa-4986-b441-80250b48c0e7.png">

