### PR TITLE
add missing props to CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,32 +5,45 @@
 | @abmsourav | @sourav926 |
 | @aristath | @aristath |
 | @audrasjb | @audrasjb |
+| @beafialho |  |
 | @bgardner | @bgardner |
 | @briceduclos | @briceduclos |
 | @carolinan | @poena |
+| @clucasrowlands |  |
 | @colorful-tones | @colorful-tones |
+| @desrosj |  |
 | @dgwyer | @dgwyer |
 | @dimadin | @dimadin |
 | @gregrickaby | @gregrickaby |
 | @ellenbauer | @ellenbauer |
+| @felixarntz |  |
+| @jasmussen |  |
 | @jffng | @jffng |
+| @juricav |  |
 | @iwangdu | @ |
 | @kafleg | @kafleg |
 | @karmatosed | @karmatosed |
 | @kraftbj | @kraftbj |
 | @kjellr | @kjellr |
 | @littlebigthing | @littlebigthing |
+| @luminuu |  |
 | @maggiecabrera | @onemaggie |
+| @melchoyce |  |
 | @mtias | @matveb |
 | @mburridge | @mburridge |
 | @mtoensing | @mtoensing |
 | @nickcernis | @nickcernis |
 | @nielslange | @nielslange |
+| @ntwb |  |
+| @otto42 |  |
 | @pattonwebz | @williampatton |
 | @pbking | @pbking |
 | @ribaricplusplus | @ribaricplusplus |
 | @richtabor | @onemaggie |
+| @riyadh1734 |  |
+| @sandstromer |  |
 | @scruffian | @scruffian |
 | @soean | @soean |
 | @tebenachi | @utz119 |
+| @westonruter |  |
 | @youknowriad | @youknowriad |

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,45 +5,45 @@
 | @abmsourav | @sourav926 |
 | @aristath | @aristath |
 | @audrasjb | @audrasjb |
-| @beafialho |  |
+| @beafialho | @beafialho |
 | @bgardner | @bgardner |
 | @briceduclos | @briceduclos |
 | @carolinan | @poena |
-| @clucasrowlands |  |
+| @clucasrowlands | @clucasrowlands |
 | @colorful-tones | @colorful-tones |
-| @desrosj |  |
+| @desrosj | @desrosj |
 | @dgwyer | @dgwyer |
 | @dimadin | @dimadin |
 | @gregrickaby | @gregrickaby |
 | @ellenbauer | @ellenbauer |
-| @felixarntz |  |
-| @jasmussen |  |
+| @felixarntz | @flixos90 |
+| @jasmussen | @joen |
 | @jffng | @jffng |
-| @juricav |  |
-| @iwangdu | @ |
+| @juricav | UNKNOWN |
+| @iwangdu | UNKNOWN |
 | @kafleg | @kafleg |
 | @karmatosed | @karmatosed |
 | @kraftbj | @kraftbj |
 | @kjellr | @kjellr |
 | @littlebigthing | @littlebigthing |
-| @luminuu |  |
+| @luminuu | @luminuu |
 | @maggiecabrera | @onemaggie |
-| @melchoyce |  |
+| @melchoyce | @melchoyce |
 | @mtias | @matveb |
 | @mburridge | @mburridge |
 | @mtoensing | @mtoensing |
 | @nickcernis | @nickcernis |
 | @nielslange | @nielslange |
-| @ntwb |  |
-| @otto42 |  |
+| @ntwb | @netweb |
+| @otto42 | @otto42 |
 | @pattonwebz | @williampatton |
 | @pbking | @pbking |
 | @ribaricplusplus | @ribaricplusplus |
 | @richtabor | @onemaggie |
-| @riyadh1734 |  |
-| @sandstromer |  |
+| @riyadh1734 | @saju4wordpress |
+| @sandstromer | UNKNOWN |
 | @scruffian | @scruffian |
 | @soean | @soean |
 | @tebenachi | @utz119 |
-| @westonruter |  |
+| @westonruter | @westonruter |
 | @youknowriad | @youknowriad |

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -39,7 +39,7 @@
 | @pattonwebz | @williampatton |
 | @pbking | @pbking |
 | @ribaricplusplus | @ribaricplusplus |
-| @richtabor | @onemaggie |
+| @richtabor | @richtabor |
 | @riyadh1734 | @saju4wordpress |
 | @sandstromer | UNKNOWN |
 | @scruffian | @scruffian |


### PR DESCRIPTION
**Description**

Note that some of the references below are not the only contributions (commits, PR review, helpful issue input, etc.) from these folks, but merely the first ones I encountered while reviewing items committed to `trunk` since the initial branch commit.

@westonruter via  #51
@ntwb via #73
@juricav via #113
@sandstromer via #69
@jasmussen via #74
@melchoyce via #16
@riyadh1734 via #182
@desrosj via #223
@beafialho via #172
@clucasrowlands via #171
@otto42 via #28
@luminuu via #107
@felixarntz via #240

I still need to add the WordPress.org Usernames, but wanted to get this draft PR up now while I work to find those second pieces of info.

Relates to #59.

**Screenshots**

n/a

**Testing Instructions** 

n/a
