### PR TITLE
Fix header.html markup

### DIFF
--- a/block-template-parts/header.html
+++ b/block-template-parts/header.html
@@ -1,7 +1,6 @@
-<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--small, 1.25rem)","top":"var(--wp--custom--spacing--large, 8rem)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--large, 8rem)","top":"var(--wp--custom--spacing--small, 1.25rem)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide" style="padding-top:var(--wp--custom--spacing--small, 1.25rem);padding-bottom:var(--wp--custom--spacing--large, 8rem)"><!-- wp:group {"layout":{"type":"flex"}} -->
-<div class="wp-block-group">
-<!-- wp:site-logo {"width":64} /-->
+<div class="wp-block-group"><!-- wp:site-logo {"width":64} /-->
 
 <!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /--></div>
 <!-- /wp:group -->


### PR DESCRIPTION
The latest changes to `header.html` have a little typo in them that's causing a markup error in the editor:

Before|After
---|--
<img width="1449" alt="Screen Shot 2021-11-16 at 7 15 13 PM" src="https://user-images.githubusercontent.com/1202812/142086343-eab06e4c-a80c-4e62-abe6-84270294b3c5.png">|<img width="1452" alt="Screen Shot 2021-11-16 at 7 14 38 PM" src="https://user-images.githubusercontent.com/1202812/142086347-dbec4d00-9289-426e-97ac-6475e27b0ff0.png">
