### PR TITLE
Add the remaining header template part to theme.json

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -356,12 +356,12 @@
 		},
 		{
 			"name": "header-large-dark",
-			"title": "Header — Dark",
+			"title": "Header (Dark, large)",
 			"area": "header"
 		},
 		{
 			"name": "header-small-dark",
-			"title": "Header — Dark, small",
+			"title": "Header (Dark, small)",
 			"area": "header"
 		},
 		{

--- a/theme.json
+++ b/theme.json
@@ -360,6 +360,11 @@
 			"area": "header"
 		},
 		{
+			"name": "header-small-dark",
+			"title": "Header — Dark, small",
+			"area": "header"
+		},
+		{
 			"name": "footer",
 			"title": "Footer",
 			"area": "footer"


### PR DESCRIPTION
**Description**
Add the reamining header template part to theme.json.

**Screenshots**

Before and after:
![two views of the template part list in the site editor, the left image shows the name of the template part, the right image shows the title of the template part.](https://user-images.githubusercontent.com/7422055/142602531-a4307b17-b28e-4062-93a0-85428b78f0d9.png)

**Testing Instructions** 
1. With Gutenberg trunk active. open the list of template parts in the site editor.
2. See that the name of the template part is the added title.
