### PR TITLE
Improve `twentytwentytwo_preload_webfonts` docs

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -126,10 +126,10 @@ if ( ! function_exists( 'twentytwentytwo_preload_webfonts' ) ) :
 	/**
 	 * Preloads the main web font to improve performance.
 	 *
-	 * Only the main web font (font-style: normal) is preloaded here since that font is always relevant (e.g. it used
-	 * on every heading). The other font is only needed if there is any applicable content in italic style, and
-	 * therefore preloading it would in most cases regress performance when that font would otherwise not be loaded at
-	 * all.
+	 * Only the main web font (font-style: normal) is preloaded here since that font is always relevant (it is used
+	 * on every heading, for example). The other font is only needed if there is any applicable content in italic style,
+	 * and therefore preloading it would in most cases regress performance when that font would otherwise not be loaded
+	 * at all.
 	 *
 	 * @since Twenty Twenty-Two 1.0
 	 *


### PR DESCRIPTION
- Adds the missing word "is"
- Changes the "e.g." abbreviation to "for example" ([see WordPress changeset 52215](https://core.trac.wordpress.org/changeset/52215))
- Moves words to the next line for slightly more consistent width