### PR TITLE
Try a subtle opacity change on button hovers

### DIFF
--- a/style.css
+++ b/style.css
@@ -65,6 +65,14 @@ a:active {
 	padding: calc(.667em + 2px) calc(1.333em + 2px);
 }
 
-.wp-block-file a.wp-block-file__button:hover {
-	opacity: 1;
-}
+/*
+ * Button hover styles.
+ * Necessary until the following issue is resolved in Gutenberg:
+ * https://github.com/WordPress/gutenberg/issues/27075
+ */
+
+.wp-block-search__button:hover,
+.wp-block-file .wp-block-file__button:hover,
+.wp-block-button__link:hover {
+	opacity: 0.85;
+} 

--- a/style.css
+++ b/style.css
@@ -74,5 +74,5 @@ a:active {
 .wp-block-search__button:hover,
 .wp-block-file .wp-block-file__button:hover,
 .wp-block-button__link:hover {
-	opacity: 0.85;
+	opacity: 0.90;
 } 


### PR DESCRIPTION
Fixes #99.

Tries a subtle opacity adjustment for button hovers. It's a single CSS rule, generally works ok, and will mostly still let folks choose hover colors when/if that feature gets rolled into core. From a pure visual design perspective, it's not my first choice but it looks acceptable. If we're implementing button hovers, I think this is our best bet. 

The only real downside is that it's not totally obvious that there's a hover state for outlined buttons on light backgrounds. But it still might be better than what we've got (which is no hover state at all). 

## Screenshots
![buttons](https://user-images.githubusercontent.com/1202812/144667076-8f211539-aba9-41e0-90a5-a598f4f3ac02.gif)
![buttons-2](https://user-images.githubusercontent.com/1202812/144667079-0a700468-259c-4095-b918-6ae7bc6e0608.gif)

