### PR TITLE
Use get_theme_file_path to load block patterns

### DIFF
--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -124,7 +124,7 @@ function twentytwentytwo_register_block_patterns() {
 
 		register_block_pattern(
 			'twentytwentytwo/' . $block_pattern,
-			require $pattern_file 
+			require $pattern_file
 		);
 	}
 }

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -120,9 +120,11 @@ function twentytwentytwo_register_block_patterns() {
 	$block_patterns = apply_filters( 'twentytwentytwo_block_patterns', $block_patterns );
 
 	foreach ( $block_patterns as $block_pattern ) {
+		$pattern_file = get_theme_file_path( '/inc/patterns/' . $block_pattern . '.php' );
+
 		register_block_pattern(
 			'twentytwentytwo/' . $block_pattern,
-			require __DIR__ . '/patterns/' . $block_pattern . '.php'
+			require $pattern_file 
 		);
 	}
 }


### PR DESCRIPTION
**Description**

This PR solves #221. It allows a child theme to override a pattern by including a file at the same location. This way, updates to the other patterns would still be preserved. 

**Testing Instructions** 

Ensure all the patterns still load as expected in TT2.

Bonus:

1. Create a twentytwentytwo child theme and activate it
2. Add a pattern with the same name (e.g. `inc/pattern/footer-default.php`)
3. Change something in the pattern, go to the post editor, ensure the editor loads the child theme's version of the pattern.
