### PR TITLE
Try adding a hover state for navigation items

### DIFF
--- a/style.css
+++ b/style.css
@@ -48,7 +48,8 @@ a:active {
 	text-decoration: none;
 }
 
-.wp-block-navigation .wp-block-navigation-item a:hover {
+.wp-block-navigation .wp-block-navigation-item a:hover,
+.wp-block-navigation .wp-block-navigation-item a:focus {
 	text-decoration: underline;
 	text-decoration-style: solid;
 }

--- a/style.css
+++ b/style.css
@@ -29,7 +29,7 @@ body {
 }
 
 /*
- * Text link styles.
+ * Text and navigation link styles.
  * Necessary until the following issue is resolved in Gutenberg:
  * https://github.com/WordPress/gutenberg/issues/27075
  */
@@ -46,6 +46,11 @@ a:focus {
 
 a:active {
 	text-decoration: none;
+}
+
+.wp-block-navigation .wp-block-navigation-item a:hover {
+	text-decoration: underline;
+	text-decoration-style: solid;
 }
 
 /*


### PR DESCRIPTION
This adds an underline hover state for nav items. It's just a few lines of code, and I think it's reasonable alongside the other hover state code we've implemented already. 

I've tested this with other nav block content that might contain links too (social links, site logo with link, etc). But the CSS specificity used here seems to work as expected.

Before|After
---|---
![hover-default](https://user-images.githubusercontent.com/1202812/145100793-2029a230-ee07-4655-b84d-ad6c87dc6754.gif)|![hover-underline](https://user-images.githubusercontent.com/1202812/145100800-524018ee-75ad-4a5c-a97c-27dafc22e688.gif)


