### PR TITLE
Try using the default categories

### DIFF
--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -12,7 +12,7 @@
  */
 function twentytwentytwo_register_block_patterns() {
 	$block_pattern_categories = array(
-		'general' => array( 'label' => __( 'General', 'twentytwentytwo' ) ),
+		'featured' => array( 'label' => __( 'Featured', 'twentytwentytwo' ) ),
 		'footer' => array( 'label' => __( 'Footers', 'twentytwentytwo' ) ),
 		'header' => array( 'label' => __( 'Headers', 'twentytwentytwo' ) ),
 		'query'   => array( 'label' => __( 'Query', 'twentytwentytwo' ) ),

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -12,11 +12,11 @@
  */
 function twentytwentytwo_register_block_patterns() {
 	$block_pattern_categories = array(
-		'twentytwentytwo-general' => array( 'label' => __( 'Twenty Twenty-Two General', 'twentytwentytwo' ) ),
-		'twentytwentytwo-footers' => array( 'label' => __( 'Twenty Twenty-Two Footers', 'twentytwentytwo' ) ),
-		'twentytwentytwo-headers' => array( 'label' => __( 'Twenty Twenty-Two Headers', 'twentytwentytwo' ) ),
-		'twentytwentytwo-query'   => array( 'label' => __( 'Twenty Twenty-Two Posts', 'twentytwentytwo' ) ),
-		'twentytwentytwo-pages'   => array( 'label' => __( 'Twenty Twenty-Two Pages', 'twentytwentytwo' ) ),
+		'general' => array( 'label' => __( 'General', 'twentytwentytwo' ) ),
+		'footers' => array( 'label' => __( 'Footers', 'twentytwentytwo' ) ),
+		'headers' => array( 'label' => __( 'Headers', 'twentytwentytwo' ) ),
+		'query'   => array( 'label' => __( 'Query', 'twentytwentytwo' ) ),
+		'pages'   => array( 'label' => __( 'Pages', 'twentytwentytwo' ) ),
 	);
 
 	/**
@@ -37,7 +37,9 @@ function twentytwentytwo_register_block_patterns() {
 	$block_pattern_categories = apply_filters( 'twentytwentytwo_block_pattern_categories', $block_pattern_categories );
 
 	foreach ( $block_pattern_categories as $name => $properties ) {
-		register_block_pattern_category( $name, $properties );
+		if ( ! WP_Block_Pattern_Categories_Registry::get_instance()->is_registered( $name ) ) {
+			register_block_pattern_category( $name, $properties );
+		}
 	}
 
 	$block_patterns = array(

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -13,8 +13,8 @@
 function twentytwentytwo_register_block_patterns() {
 	$block_pattern_categories = array(
 		'general' => array( 'label' => __( 'General', 'twentytwentytwo' ) ),
-		'footers' => array( 'label' => __( 'Footers', 'twentytwentytwo' ) ),
-		'headers' => array( 'label' => __( 'Headers', 'twentytwentytwo' ) ),
+		'footer' => array( 'label' => __( 'Footers', 'twentytwentytwo' ) ),
+		'header' => array( 'label' => __( 'Headers', 'twentytwentytwo' ) ),
 		'query'   => array( 'label' => __( 'Query', 'twentytwentytwo' ) ),
 		'pages'   => array( 'label' => __( 'Pages', 'twentytwentytwo' ) ),
 	);

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -15,7 +15,7 @@ function twentytwentytwo_register_block_patterns() {
 		'featured' => array( 'label' => __( 'Featured', 'twentytwentytwo' ) ),
 		'footer' => array( 'label' => __( 'Footers', 'twentytwentytwo' ) ),
 		'header' => array( 'label' => __( 'Headers', 'twentytwentytwo' ) ),
-		'query'   => array( 'label' => __( 'Query', 'twentytwentytwo' ) ),
+		'posts'   => array( 'label' => __( 'Posts', 'twentytwentytwo' ) ),
 		'pages'   => array( 'label' => __( 'Pages', 'twentytwentytwo' ) ),
 	);
 

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -15,7 +15,7 @@ function twentytwentytwo_register_block_patterns() {
 		'featured' => array( 'label' => __( 'Featured', 'twentytwentytwo' ) ),
 		'footer' => array( 'label' => __( 'Footers', 'twentytwentytwo' ) ),
 		'header' => array( 'label' => __( 'Headers', 'twentytwentytwo' ) ),
-		'posts'   => array( 'label' => __( 'Posts', 'twentytwentytwo' ) ),
+		'query'   => array( 'label' => __( 'Query', 'twentytwentytwo' ) ),
 		'pages'   => array( 'label' => __( 'Pages', 'twentytwentytwo' ) ),
 	);
 

--- a/inc/patterns/footer-about-title-logo.php
+++ b/inc/patterns/footer-about-title-logo.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Footer with text, title, and logo', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-footers' ),
+	'categories' => array( 'footers' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"8rem","bottom":"6rem"}}},"backgroundColor":"secondary","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-secondary-background-color has-background" style="padding-top:8rem;padding-bottom:6rem"><!-- wp:columns {"align":"wide"} -->

--- a/inc/patterns/footer-about-title-logo.php
+++ b/inc/patterns/footer-about-title-logo.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Footer with text, title, and logo', 'twentytwentytwo' ),
-	'categories' => array( 'footers' ),
+	'categories' => array( 'footer' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"8rem","bottom":"6rem"}}},"backgroundColor":"secondary","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-secondary-background-color has-background" style="padding-top:8rem;padding-bottom:6rem"><!-- wp:columns {"align":"wide"} -->

--- a/inc/patterns/footer-blog.php
+++ b/inc/patterns/footer-blog.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Blog footer', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-footers' ),
+	'categories' => array( 'footers' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"8rem","bottom":"8rem"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-top:8rem;padding-bottom:8rem"><!-- wp:columns -->

--- a/inc/patterns/footer-blog.php
+++ b/inc/patterns/footer-blog.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Blog footer', 'twentytwentytwo' ),
-	'categories' => array( 'footers' ),
+	'categories' => array( 'footer' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"8rem","bottom":"8rem"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-top:8rem;padding-bottom:8rem"><!-- wp:columns -->

--- a/inc/patterns/footer-dark.php
+++ b/inc/patterns/footer-dark.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Dark footer with title and citation', 'twentytwentytwo' ),
-	'categories' => array( 'footers' ),
+	'categories' => array( 'footer' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/footer-dark.php
+++ b/inc/patterns/footer-dark.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Dark footer with title and citation', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-footers' ),
+	'categories' => array( 'footers' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/footer-default.php
+++ b/inc/patterns/footer-default.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Default footer', 'twentytwentytwo' ),
-	'categories' => array( 'footers' ),
+	'categories' => array( 'footer' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/footer-default.php
+++ b/inc/patterns/footer-default.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Default footer', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-footers' ),
+	'categories' => array( 'footers' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/footer-logo.php
+++ b/inc/patterns/footer-logo.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Footer with logo and citation', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-footers' ),
+	'categories' => array( 'footers' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/footer-logo.php
+++ b/inc/patterns/footer-logo.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Footer with logo and citation', 'twentytwentytwo' ),
-	'categories' => array( 'footers' ),
+	'categories' => array( 'footer' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/footer-navigation-copyright.php
+++ b/inc/patterns/footer-navigation-copyright.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Footer with navigation and copyright', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-footers' ),
+	'categories' => array( 'footers' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}}}} -->
 					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"center"}} -->

--- a/inc/patterns/footer-navigation-copyright.php
+++ b/inc/patterns/footer-navigation-copyright.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Footer with navigation and copyright', 'twentytwentytwo' ),
-	'categories' => array( 'footers' ),
+	'categories' => array( 'footer' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}}}} -->
 					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"center"}} -->

--- a/inc/patterns/footer-navigation.php
+++ b/inc/patterns/footer-navigation.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Footer with navigation and citation', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-footers' ),
+	'categories' => array( 'footers' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/footer-navigation.php
+++ b/inc/patterns/footer-navigation.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Footer with navigation and citation', 'twentytwentytwo' ),
-	'categories' => array( 'footers' ),
+	'categories' => array( 'footer' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/footer-query-images-title-citation.php
+++ b/inc/patterns/footer-query-images-title-citation.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Footer with query, featured images, title, and citation', 'twentytwentytwo' ),
-	'categories' => array( 'footers' ),
+	'categories' => array( 'footer' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3},"align":"wide"} -->

--- a/inc/patterns/footer-query-images-title-citation.php
+++ b/inc/patterns/footer-query-images-title-citation.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Footer with query, featured images, title, and citation', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-footers' ),
+	'categories' => array( 'footers' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3},"align":"wide"} -->

--- a/inc/patterns/footer-query-title-citation.php
+++ b/inc/patterns/footer-query-title-citation.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Footer with query, title, and citation', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-footers' ),
+	'categories' => array( 'footers' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"primary","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-primary-background-color has-text-color has-background has-link-color" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3},"align":"wide"} -->

--- a/inc/patterns/footer-query-title-citation.php
+++ b/inc/patterns/footer-query-title-citation.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Footer with query, title, and citation', 'twentytwentytwo' ),
-	'categories' => array( 'footers' ),
+	'categories' => array( 'footer' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"primary","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-primary-background-color has-text-color has-background has-link-color" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3},"align":"wide"} -->

--- a/inc/patterns/footer-social-copyright.php
+++ b/inc/patterns/footer-social-copyright.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Footer with social links and copyright', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-footers' ),
+	'categories' => array( 'footers' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}}}} -->
 					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:social-links {"iconColor":"foreground","iconColorValue":"var(--wp--preset--color--foreground)","iconBackgroundColor":"background","iconBackgroundColorValue":"var(--wp--preset--color--background)","layout":{"type":"flex","justifyContent":"center"}} -->

--- a/inc/patterns/footer-social-copyright.php
+++ b/inc/patterns/footer-social-copyright.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Footer with social links and copyright', 'twentytwentytwo' ),
-	'categories' => array( 'footers' ),
+	'categories' => array( 'footer' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}}}} -->
 					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:social-links {"iconColor":"foreground","iconColorValue":"var(--wp--preset--color--foreground)","iconBackgroundColor":"background","iconBackgroundColorValue":"var(--wp--preset--color--background)","layout":{"type":"flex","justifyContent":"center"}} -->

--- a/inc/patterns/footer-title-tagline-social.php
+++ b/inc/patterns/footer-title-tagline-social.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Footer with title, tagline, and social links on a dark background', 'twentytwentytwo' ),
-	'categories' => array( 'footers' ),
+	'categories' => array( 'footer' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/footer-title-tagline-social.php
+++ b/inc/patterns/footer-title-tagline-social.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Footer with title, tagline, and social links on a dark background', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-footers' ),
+	'categories' => array( 'footers' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/general-divider-dark.php
+++ b/inc/patterns/general-divider-dark.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Divider with image and color (dark)', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-general' ),
+	'categories' => array( 'general' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"1rem","right":"0px","bottom":"1rem","left":"0px"}}},"backgroundColor":"primary"} -->
 					<div class="wp-block-group alignfull has-primary-background-color has-background" style="padding-top:1rem;padding-right:0px;padding-bottom:1rem;padding-left:0px"><!-- wp:image {"id":473,"sizeSlug":"full","linkDestination":"none"} -->
 					<figure class="wp-block-image size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/divider-white.png" alt="" class="wp-image-473"/></figure>

--- a/inc/patterns/general-divider-dark.php
+++ b/inc/patterns/general-divider-dark.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Divider with image and color (dark)', 'twentytwentytwo' ),
-	'categories' => array( 'general' ),
+	'categories' => array( 'featured' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"1rem","right":"0px","bottom":"1rem","left":"0px"}}},"backgroundColor":"primary"} -->
 					<div class="wp-block-group alignfull has-primary-background-color has-background" style="padding-top:1rem;padding-right:0px;padding-bottom:1rem;padding-left:0px"><!-- wp:image {"id":473,"sizeSlug":"full","linkDestination":"none"} -->
 					<figure class="wp-block-image size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/divider-white.png" alt="" class="wp-image-473"/></figure>

--- a/inc/patterns/general-divider-light.php
+++ b/inc/patterns/general-divider-light.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Divider with image and color (light)', 'twentytwentytwo' ),
-	'categories' => array( 'general' ),
+	'categories' => array( 'featured' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"1rem","right":"0px","bottom":"1rem","left":"0px"}}},"backgroundColor":"secondary"} -->
 					<div class="wp-block-group alignfull has-secondary-background-color has-background" style="padding-top:1rem;padding-right:0px;padding-bottom:1rem;padding-left:0px"><!-- wp:image {"id":473,"sizeSlug":"full","linkDestination":"none"} -->
 					<figure class="wp-block-image size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/divider-black.png" alt="" class="wp-image-473"/></figure>

--- a/inc/patterns/general-divider-light.php
+++ b/inc/patterns/general-divider-light.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Divider with image and color (light)', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-general' ),
+	'categories' => array( 'general' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"1rem","right":"0px","bottom":"1rem","left":"0px"}}},"backgroundColor":"secondary"} -->
 					<div class="wp-block-group alignfull has-secondary-background-color has-background" style="padding-top:1rem;padding-right:0px;padding-bottom:1rem;padding-left:0px"><!-- wp:image {"id":473,"sizeSlug":"full","linkDestination":"none"} -->
 					<figure class="wp-block-image size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/divider-black.png" alt="" class="wp-image-473"/></figure>

--- a/inc/patterns/general-featured-posts.php
+++ b/inc/patterns/general-featured-posts.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Featured posts', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-general' ),
+	'categories' => array( 'general' ),
 	'content'    => '<!-- wp:group {"align":"wide","layout":{"inherit":false}} -->
 					<div class="wp-block-group alignwide"><!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}}} -->
 					<p style="text-transform:uppercase">' . esc_html__( 'Latest posts', 'twentytwentytwo' ) . '</p>

--- a/inc/patterns/general-featured-posts.php
+++ b/inc/patterns/general-featured-posts.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Featured posts', 'twentytwentytwo' ),
-	'categories' => array( 'general' ),
+	'categories' => array( 'featured' ),
 	'content'    => '<!-- wp:group {"align":"wide","layout":{"inherit":false}} -->
 					<div class="wp-block-group alignwide"><!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}}} -->
 					<p style="text-transform:uppercase">' . esc_html__( 'Latest posts', 'twentytwentytwo' ) . '</p>

--- a/inc/patterns/general-featured-posts.php
+++ b/inc/patterns/general-featured-posts.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Featured posts', 'twentytwentytwo' ),
-	'categories' => array( 'featured', 'posts' ),
+	'categories' => array( 'featured', 'query' ),
 	'content'    => '<!-- wp:group {"align":"wide","layout":{"inherit":false}} -->
 					<div class="wp-block-group alignwide"><!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}}} -->
 					<p style="text-transform:uppercase">' . esc_html__( 'Latest posts', 'twentytwentytwo' ) . '</p>

--- a/inc/patterns/general-featured-posts.php
+++ b/inc/patterns/general-featured-posts.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Featured posts', 'twentytwentytwo' ),
-	'categories' => array( 'featured' ),
+	'categories' => array( 'featured', 'posts' ),
 	'content'    => '<!-- wp:group {"align":"wide","layout":{"inherit":false}} -->
 					<div class="wp-block-group alignwide"><!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}}} -->
 					<p style="text-transform:uppercase">' . esc_html__( 'Latest posts', 'twentytwentytwo' ) . '</p>

--- a/inc/patterns/general-image-with-caption.php
+++ b/inc/patterns/general-image-with-caption.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Image with caption', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-general' ),
+	'categories' => array( 'general' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"6rem","right":"max(1.25rem, 5vw)","bottom":"6rem","left":"max(1.25rem, 5vw)"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"primary","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-primary-background-color has-text-color has-background has-link-color" style="padding-top:6rem;padding-right:max(1.25rem, 5vw);padding-bottom:6rem;padding-left:max(1.25rem, 5vw)"><!-- wp:media-text {"mediaId":202,"mediaLink":"' . esc_url( get_template_directory_uri() ) . '/assets/images/bird-on-gray.jpg","mediaType":"image","verticalAlignment":"bottom","imageFill":false} -->
 					<div class="wp-block-media-text alignwide is-stacked-on-mobile is-vertically-aligned-bottom"><figure class="wp-block-media-text__media"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/bird-on-gray.jpg" alt="' . esc_attr__( 'Hummingbird illustration', 'twentytwentytwo' ) . '" class="wp-image-202 size-full"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph -->

--- a/inc/patterns/general-image-with-caption.php
+++ b/inc/patterns/general-image-with-caption.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Image with caption', 'twentytwentytwo' ),
-	'categories' => array( 'general' ),
+	'categories' => array( 'general', 'columns' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"6rem","right":"max(1.25rem, 5vw)","bottom":"6rem","left":"max(1.25rem, 5vw)"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"primary","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-primary-background-color has-text-color has-background has-link-color" style="padding-top:6rem;padding-right:max(1.25rem, 5vw);padding-bottom:6rem;padding-left:max(1.25rem, 5vw)"><!-- wp:media-text {"mediaId":202,"mediaLink":"' . esc_url( get_template_directory_uri() ) . '/assets/images/bird-on-gray.jpg","mediaType":"image","verticalAlignment":"bottom","imageFill":false} -->
 					<div class="wp-block-media-text alignwide is-stacked-on-mobile is-vertically-aligned-bottom"><figure class="wp-block-media-text__media"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/bird-on-gray.jpg" alt="' . esc_attr__( 'Hummingbird illustration', 'twentytwentytwo' ) . '" class="wp-image-202 size-full"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph -->

--- a/inc/patterns/general-image-with-caption.php
+++ b/inc/patterns/general-image-with-caption.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Image with caption', 'twentytwentytwo' ),
-	'categories' => array( 'general', 'columns' ),
+	'categories' => array( 'featured', 'columns' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"6rem","right":"max(1.25rem, 5vw)","bottom":"6rem","left":"max(1.25rem, 5vw)"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"primary","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-primary-background-color has-text-color has-background has-link-color" style="padding-top:6rem;padding-right:max(1.25rem, 5vw);padding-bottom:6rem;padding-left:max(1.25rem, 5vw)"><!-- wp:media-text {"mediaId":202,"mediaLink":"' . esc_url( get_template_directory_uri() ) . '/assets/images/bird-on-gray.jpg","mediaType":"image","verticalAlignment":"bottom","imageFill":false} -->
 					<div class="wp-block-media-text alignwide is-stacked-on-mobile is-vertically-aligned-bottom"><figure class="wp-block-media-text__media"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/bird-on-gray.jpg" alt="' . esc_attr__( 'Hummingbird illustration', 'twentytwentytwo' ) . '" class="wp-image-202 size-full"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph -->

--- a/inc/patterns/general-image-with-caption.php
+++ b/inc/patterns/general-image-with-caption.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Image with caption', 'twentytwentytwo' ),
-	'categories' => array( 'featured', 'columns' ),
+	'categories' => array( 'featured', 'columns', 'gallery' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"6rem","right":"max(1.25rem, 5vw)","bottom":"6rem","left":"max(1.25rem, 5vw)"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"primary","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-primary-background-color has-text-color has-background has-link-color" style="padding-top:6rem;padding-right:max(1.25rem, 5vw);padding-bottom:6rem;padding-left:max(1.25rem, 5vw)"><!-- wp:media-text {"mediaId":202,"mediaLink":"' . esc_url( get_template_directory_uri() ) . '/assets/images/bird-on-gray.jpg","mediaType":"image","verticalAlignment":"bottom","imageFill":false} -->
 					<div class="wp-block-media-text alignwide is-stacked-on-mobile is-vertically-aligned-bottom"><figure class="wp-block-media-text__media"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/bird-on-gray.jpg" alt="' . esc_attr__( 'Hummingbird illustration', 'twentytwentytwo' ) . '" class="wp-image-202 size-full"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph -->

--- a/inc/patterns/general-large-list-names.php
+++ b/inc/patterns/general-large-list-names.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Large list of names', 'twentytwentytwo' ),
-	'categories' => array( 'general', 'text' ),
+	'categories' => array( 'featured', 'text' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"6rem","right":"max(1.25rem, 5vw)","bottom":"6rem","left":"max(1.25rem, 5vw)"}},"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"backgroundColor":"tertiary","textColor":"primary","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-primary-color has-tertiary-background-color has-text-color has-background has-link-color" style="padding-top:6rem;padding-right:max(1.25rem, 5vw);padding-bottom:6rem;padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide"} -->
 					<div class="wp-block-group alignwide"><!-- wp:image {"width":175,"height":82,"sizeSlug":"full","linkDestination":"none"} -->

--- a/inc/patterns/general-large-list-names.php
+++ b/inc/patterns/general-large-list-names.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Large list of names', 'twentytwentytwo' ),
-	'categories' => array( 'general' ),
+	'categories' => array( 'general', 'text' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"6rem","right":"max(1.25rem, 5vw)","bottom":"6rem","left":"max(1.25rem, 5vw)"}},"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"backgroundColor":"tertiary","textColor":"primary","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-primary-color has-tertiary-background-color has-text-color has-background has-link-color" style="padding-top:6rem;padding-right:max(1.25rem, 5vw);padding-bottom:6rem;padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide"} -->
 					<div class="wp-block-group alignwide"><!-- wp:image {"width":175,"height":82,"sizeSlug":"full","linkDestination":"none"} -->

--- a/inc/patterns/general-large-list-names.php
+++ b/inc/patterns/general-large-list-names.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Large list of names', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-general' ),
+	'categories' => array( 'general' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"6rem","right":"max(1.25rem, 5vw)","bottom":"6rem","left":"max(1.25rem, 5vw)"}},"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"backgroundColor":"tertiary","textColor":"primary","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-primary-color has-tertiary-background-color has-text-color has-background has-link-color" style="padding-top:6rem;padding-right:max(1.25rem, 5vw);padding-bottom:6rem;padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide"} -->
 					<div class="wp-block-group alignwide"><!-- wp:image {"width":175,"height":82,"sizeSlug":"full","linkDestination":"none"} -->

--- a/inc/patterns/general-layered-images-with-duotone.php
+++ b/inc/patterns/general-layered-images-with-duotone.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Layered images with duotone', 'twentytwentytwo' ),
-	'categories' => array( 'featured' ),
+	'categories' => array( 'featured', 'gallery' ),
 	'content'    => '<!-- wp:cover {"url":"' . esc_url( get_template_directory_uri() ) . '/assets/images/ducks.jpg","dimRatio":0,"minHeight":666,"contentPosition":"center center","isDark":false,"align":"wide","style":{"spacing":{"padding":{"top":"1em","right":"1em","bottom":"1em","left":"1em"}},"color":{"duotone":["#000000","#FFFFFF"]}}} -->
 					<div class="wp-block-cover alignwide is-light" style="padding-top:1em;padding-right:1em;padding-bottom:1em;padding-left:1em;min-height:666px"><span aria-hidden="true" class="has-background-dim-0 wp-block-cover__gradient-background has-background-dim"></span><img class="wp-block-cover__image-background" alt="' . esc_attr__( 'Painting of ducks in the water.', 'twentytwentytwo' ) . '" src="' . esc_url( get_template_directory_uri() ) . '/assets/images/ducks.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:image {"align":"center","width":384,"height":580,"sizeSlug":"large"} -->
 					<div class="wp-block-image"><figure class="aligncenter size-large is-resized"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/flight-path-on-salmon.jpg" alt="' . esc_attr__( 'Illustration of a flying bird.', 'twentytwentytwo' ) . '" width="384" height="580"/></figure></div>

--- a/inc/patterns/general-layered-images-with-duotone.php
+++ b/inc/patterns/general-layered-images-with-duotone.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Layered images with duotone', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-general' ),
+	'categories' => array( 'general' ),
 	'content'    => '<!-- wp:cover {"url":"' . esc_url( get_template_directory_uri() ) . '/assets/images/ducks.jpg","dimRatio":0,"minHeight":666,"contentPosition":"center center","isDark":false,"align":"wide","style":{"spacing":{"padding":{"top":"1em","right":"1em","bottom":"1em","left":"1em"}},"color":{"duotone":["#000000","#FFFFFF"]}}} -->
 					<div class="wp-block-cover alignwide is-light" style="padding-top:1em;padding-right:1em;padding-bottom:1em;padding-left:1em;min-height:666px"><span aria-hidden="true" class="has-background-dim-0 wp-block-cover__gradient-background has-background-dim"></span><img class="wp-block-cover__image-background" alt="' . esc_attr__( 'Painting of ducks in the water.', 'twentytwentytwo' ) . '" src="' . esc_url( get_template_directory_uri() ) . '/assets/images/ducks.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:image {"align":"center","width":384,"height":580,"sizeSlug":"large"} -->
 					<div class="wp-block-image"><figure class="aligncenter size-large is-resized"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/flight-path-on-salmon.jpg" alt="' . esc_attr__( 'Illustration of a flying bird.', 'twentytwentytwo' ) . '" width="384" height="580"/></figure></div>

--- a/inc/patterns/general-layered-images-with-duotone.php
+++ b/inc/patterns/general-layered-images-with-duotone.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Layered images with duotone', 'twentytwentytwo' ),
-	'categories' => array( 'general' ),
+	'categories' => array( 'featured' ),
 	'content'    => '<!-- wp:cover {"url":"' . esc_url( get_template_directory_uri() ) . '/assets/images/ducks.jpg","dimRatio":0,"minHeight":666,"contentPosition":"center center","isDark":false,"align":"wide","style":{"spacing":{"padding":{"top":"1em","right":"1em","bottom":"1em","left":"1em"}},"color":{"duotone":["#000000","#FFFFFF"]}}} -->
 					<div class="wp-block-cover alignwide is-light" style="padding-top:1em;padding-right:1em;padding-bottom:1em;padding-left:1em;min-height:666px"><span aria-hidden="true" class="has-background-dim-0 wp-block-cover__gradient-background has-background-dim"></span><img class="wp-block-cover__image-background" alt="' . esc_attr__( 'Painting of ducks in the water.', 'twentytwentytwo' ) . '" src="' . esc_url( get_template_directory_uri() ) . '/assets/images/ducks.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:image {"align":"center","width":384,"height":580,"sizeSlug":"large"} -->
 					<div class="wp-block-image"><figure class="aligncenter size-large is-resized"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/flight-path-on-salmon.jpg" alt="' . esc_attr__( 'Illustration of a flying bird.', 'twentytwentytwo' ) . '" width="384" height="580"/></figure></div>

--- a/inc/patterns/general-list-events.php
+++ b/inc/patterns/general-list-events.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'List of events', 'twentytwentytwo' ),
-	'categories' => array( 'general' ),
+	'categories' => array( 'general', 'text' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"8rem","bottom":"8rem","left":"0px","right":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"primary","textColor":"background"} -->
 					<div class="wp-block-group alignfull has-background-color has-primary-background-color has-text-color has-background has-link-color" style="padding-top:8rem;padding-right:0px;padding-bottom:8rem;padding-left:0px"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:heading {"align":"wide","style":{"typography":{"fontSize":"clamp(4rem, 8vw, 6.25rem)","lineHeight":"1.15"},"spacing":{"margin":{"bottom":"2rem"}}}} -->

--- a/inc/patterns/general-list-events.php
+++ b/inc/patterns/general-list-events.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'List of events', 'twentytwentytwo' ),
-	'categories' => array( 'general', 'text' ),
+	'categories' => array( 'featured', 'text' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"8rem","bottom":"8rem","left":"0px","right":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"primary","textColor":"background"} -->
 					<div class="wp-block-group alignfull has-background-color has-primary-background-color has-text-color has-background has-link-color" style="padding-top:8rem;padding-right:0px;padding-bottom:8rem;padding-left:0px"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:heading {"align":"wide","style":{"typography":{"fontSize":"clamp(4rem, 8vw, 6.25rem)","lineHeight":"1.15"},"spacing":{"margin":{"bottom":"2rem"}}}} -->

--- a/inc/patterns/general-list-events.php
+++ b/inc/patterns/general-list-events.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'List of events', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-general' ),
+	'categories' => array( 'general' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"8rem","bottom":"8rem","left":"0px","right":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"primary","textColor":"background"} -->
 					<div class="wp-block-group alignfull has-background-color has-primary-background-color has-text-color has-background has-link-color" style="padding-top:8rem;padding-right:0px;padding-bottom:8rem;padding-left:0px"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:heading {"align":"wide","style":{"typography":{"fontSize":"clamp(4rem, 8vw, 6.25rem)","lineHeight":"1.15"},"spacing":{"margin":{"bottom":"2rem"}}}} -->

--- a/inc/patterns/general-pricing-table.php
+++ b/inc/patterns/general-pricing-table.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Pricing table', 'twentytwentytwo' ),
-	'categories' => array( 'general' ),
+	'categories' => array( 'general', 'columns', 'buttons' ),
 	'content'    => '<!-- wp:columns {"align":"wide"} -->
 					<div class="wp-block-columns alignwide"><!-- wp:column -->
 					<div class="wp-block-column"><!-- wp:separator {"className":"is-style-wide"} -->

--- a/inc/patterns/general-pricing-table.php
+++ b/inc/patterns/general-pricing-table.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Pricing table', 'twentytwentytwo' ),
-	'categories' => array( 'general', 'columns', 'buttons' ),
+	'categories' => array( 'featured', 'columns', 'buttons' ),
 	'content'    => '<!-- wp:columns {"align":"wide"} -->
 					<div class="wp-block-columns alignwide"><!-- wp:column -->
 					<div class="wp-block-column"><!-- wp:separator {"className":"is-style-wide"} -->

--- a/inc/patterns/general-pricing-table.php
+++ b/inc/patterns/general-pricing-table.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Pricing table', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-general' ),
+	'categories' => array( 'general' ),
 	'content'    => '<!-- wp:columns {"align":"wide"} -->
 					<div class="wp-block-columns alignwide"><!-- wp:column -->
 					<div class="wp-block-column"><!-- wp:separator {"className":"is-style-wide"} -->

--- a/inc/patterns/general-subscribe.php
+++ b/inc/patterns/general-subscribe.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Subscribe callout', 'twentytwentytwo' ),
-	'categories' => array( 'featured' ),
+	'categories' => array( 'featured', 'buttons' ),
 	'content'    => '<!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
 					<div class="wp-block-columns alignwide are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center"} -->
 					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:heading -->

--- a/inc/patterns/general-subscribe.php
+++ b/inc/patterns/general-subscribe.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Subscribe callout', 'twentytwentytwo' ),
-	'categories' => array( 'general' ),
+	'categories' => array( 'featured' ),
 	'content'    => '<!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
 					<div class="wp-block-columns alignwide are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center"} -->
 					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:heading -->

--- a/inc/patterns/general-subscribe.php
+++ b/inc/patterns/general-subscribe.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Subscribe callout', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-general' ),
+	'categories' => array( 'general' ),
 	'content'    => '<!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
 					<div class="wp-block-columns alignwide are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center"} -->
 					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:heading -->

--- a/inc/patterns/general-two-images-text.php
+++ b/inc/patterns/general-two-images-text.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Two images with text', 'twentytwentytwo' ),
-	'categories' => array( 'general' ),
+	'categories' => array( 'general', 'columns', 'gallery' ),
 	'content'    => '<!-- wp:columns {"align":"wide"} -->
 					<div class="wp-block-columns alignwide"><!-- wp:column {"style":{"spacing":{"padding":{"top":"0rem","right":"0rem","bottom":"0rem","left":"0rem"}}}} -->
 					<div class="wp-block-column" style="padding-top:0rem;padding-right:0rem;padding-bottom:0rem;padding-left:0rem"><!-- wp:image {"sizeSlug":"large"} -->

--- a/inc/patterns/general-two-images-text.php
+++ b/inc/patterns/general-two-images-text.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Two images with text', 'twentytwentytwo' ),
-	'categories' => array( 'general', 'columns', 'gallery' ),
+	'categories' => array( 'featured', 'columns', 'gallery' ),
 	'content'    => '<!-- wp:columns {"align":"wide"} -->
 					<div class="wp-block-columns alignwide"><!-- wp:column {"style":{"spacing":{"padding":{"top":"0rem","right":"0rem","bottom":"0rem","left":"0rem"}}}} -->
 					<div class="wp-block-column" style="padding-top:0rem;padding-right:0rem;padding-bottom:0rem;padding-left:0rem"><!-- wp:image {"sizeSlug":"large"} -->

--- a/inc/patterns/general-two-images-text.php
+++ b/inc/patterns/general-two-images-text.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Two images with text', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-general' ),
+	'categories' => array( 'general' ),
 	'content'    => '<!-- wp:columns {"align":"wide"} -->
 					<div class="wp-block-columns alignwide"><!-- wp:column {"style":{"spacing":{"padding":{"top":"0rem","right":"0rem","bottom":"0rem","left":"0rem"}}}} -->
 					<div class="wp-block-column" style="padding-top:0rem;padding-right:0rem;padding-bottom:0rem;padding-left:0rem"><!-- wp:image {"sizeSlug":"large"} -->

--- a/inc/patterns/general-video-header-details.php
+++ b/inc/patterns/general-video-header-details.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Video with header and details', 'twentytwentytwo' ),
-	'categories' => array( 'featured' ),
+	'categories' => array( 'featured', 'columns' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"8rem","bottom":"8rem","left":"0px","right":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}}},"backgroundColor":"foreground","textColor":"secondary"} -->
 					<div class="wp-block-group alignfull has-secondary-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:8rem;padding-right:0px;padding-bottom:8rem;padding-left:0px"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:heading {"level":1,"align":"wide","style":{"typography":{"fontSize":"clamp(3rem, 6vw, 4.5rem)"}}} -->

--- a/inc/patterns/general-video-header-details.php
+++ b/inc/patterns/general-video-header-details.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Video with header and details', 'twentytwentytwo' ),
-	'categories' => array( 'general' ),
+	'categories' => array( 'featured' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"8rem","bottom":"8rem","left":"0px","right":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}}},"backgroundColor":"foreground","textColor":"secondary"} -->
 					<div class="wp-block-group alignfull has-secondary-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:8rem;padding-right:0px;padding-bottom:8rem;padding-left:0px"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:heading {"level":1,"align":"wide","style":{"typography":{"fontSize":"clamp(3rem, 6vw, 4.5rem)"}}} -->

--- a/inc/patterns/general-video-header-details.php
+++ b/inc/patterns/general-video-header-details.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Video with header and details', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-general' ),
+	'categories' => array( 'general' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"8rem","bottom":"8rem","left":"0px","right":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}}},"backgroundColor":"foreground","textColor":"secondary"} -->
 					<div class="wp-block-group alignfull has-secondary-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:8rem;padding-right:0px;padding-bottom:8rem;padding-left:0px"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:heading {"level":1,"align":"wide","style":{"typography":{"fontSize":"clamp(3rem, 6vw, 4.5rem)"}}} -->

--- a/inc/patterns/general-video-trailer.php
+++ b/inc/patterns/general-video-trailer.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Video trailer', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-general' ),
+	'categories' => array( 'general' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}},"spacing":{"padding":{"top":"6rem","right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","bottom":"4rem"}}},"backgroundColor":"secondary","textColor":"foreground","layout":{"inherit":true}} -->
 				<div class="wp-block-group alignfull has-foreground-color has-secondary-background-color has-text-color has-background has-link-color" style="padding-top:6rem;padding-right:max(1.25rem, 5vw);padding-bottom:4rem;padding-left:max(1.25rem, 5vw)"><!-- wp:columns {"align":"wide"} -->
 				<div class="wp-block-columns alignwide"><!-- wp:column {"width":"33.33%"} -->

--- a/inc/patterns/general-video-trailer.php
+++ b/inc/patterns/general-video-trailer.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Video trailer', 'twentytwentytwo' ),
-	'categories' => array( 'general' ),
+	'categories' => array( 'general', 'columns' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}},"spacing":{"padding":{"top":"6rem","right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","bottom":"4rem"}}},"backgroundColor":"secondary","textColor":"foreground","layout":{"inherit":true}} -->
 				<div class="wp-block-group alignfull has-foreground-color has-secondary-background-color has-text-color has-background has-link-color" style="padding-top:6rem;padding-right:max(1.25rem, 5vw);padding-bottom:4rem;padding-left:max(1.25rem, 5vw)"><!-- wp:columns {"align":"wide"} -->
 				<div class="wp-block-columns alignwide"><!-- wp:column {"width":"33.33%"} -->

--- a/inc/patterns/general-video-trailer.php
+++ b/inc/patterns/general-video-trailer.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Video trailer', 'twentytwentytwo' ),
-	'categories' => array( 'general', 'columns' ),
+	'categories' => array( 'featured', 'columns' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}},"spacing":{"padding":{"top":"6rem","right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","bottom":"4rem"}}},"backgroundColor":"secondary","textColor":"foreground","layout":{"inherit":true}} -->
 				<div class="wp-block-group alignfull has-foreground-color has-secondary-background-color has-text-color has-background has-link-color" style="padding-top:6rem;padding-right:max(1.25rem, 5vw);padding-bottom:4rem;padding-left:max(1.25rem, 5vw)"><!-- wp:columns {"align":"wide"} -->
 				<div class="wp-block-columns alignwide"><!-- wp:column {"width":"33.33%"} -->

--- a/inc/patterns/general-wide-image-intro-buttons.php
+++ b/inc/patterns/general-wide-image-intro-buttons.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Wide image with introduction and buttons', 'twentytwentytwo' ),
-	'categories' => array( 'general' ),
+	'categories' => array( 'featured' ),
 	'content'    => '<!-- wp:group {"align":"wide"} -->
 				<div class="wp-block-group alignwide"><!-- wp:image {"sizeSlug":"large"} -->
 				<figure class="wp-block-image size-large"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/flight-path-on-gray-a.jpg" alt="' . esc_attr__( 'Illustration of a bird flying.', 'twentytwentytwo' ) . '"/></figure>

--- a/inc/patterns/general-wide-image-intro-buttons.php
+++ b/inc/patterns/general-wide-image-intro-buttons.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Wide image with introduction and buttons', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-general' ),
+	'categories' => array( 'general' ),
 	'content'    => '<!-- wp:group {"align":"wide"} -->
 				<div class="wp-block-group alignwide"><!-- wp:image {"sizeSlug":"large"} -->
 				<figure class="wp-block-image size-large"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/flight-path-on-gray-a.jpg" alt="' . esc_attr__( 'Illustration of a bird flying.', 'twentytwentytwo' ) . '"/></figure>

--- a/inc/patterns/general-wide-image-intro-buttons.php
+++ b/inc/patterns/general-wide-image-intro-buttons.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Wide image with introduction and buttons', 'twentytwentytwo' ),
-	'categories' => array( 'featured' ),
+	'categories' => array( 'featured', 'columns' ),
 	'content'    => '<!-- wp:group {"align":"wide"} -->
 				<div class="wp-block-group alignwide"><!-- wp:image {"sizeSlug":"large"} -->
 				<figure class="wp-block-image size-large"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/flight-path-on-gray-a.jpg" alt="' . esc_attr__( 'Illustration of a bird flying.', 'twentytwentytwo' ) . '"/></figure>

--- a/inc/patterns/header-centered-logo-black-background.php
+++ b/inc/patterns/header-centered-logo-black-background.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Header with centered logo and black background', 'twentytwentytwo' ),
-	'categories' => array( 'headers' ),
+	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"max(1.25rem, 5vw)","top":"max(1.25rem, 5vw)"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"foreground","textColor":"background","layout":{"type":"flex","justifyContent":"center"}} -->
 					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw)"><!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} -->

--- a/inc/patterns/header-centered-logo-black-background.php
+++ b/inc/patterns/header-centered-logo-black-background.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Header with centered logo and black background', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-headers' ),
+	'categories' => array( 'headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"max(1.25rem, 5vw)","top":"max(1.25rem, 5vw)"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"foreground","textColor":"background","layout":{"type":"flex","justifyContent":"center"}} -->
 					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw)"><!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} -->

--- a/inc/patterns/header-centered-logo.php
+++ b/inc/patterns/header-centered-logo.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Header with centered logo', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-headers' ),
+	'categories' => array( 'headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"backgroundColor":"primary","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-primary-background-color has-text-color has-background has-link-color" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->

--- a/inc/patterns/header-centered-logo.php
+++ b/inc/patterns/header-centered-logo.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Header with centered logo', 'twentytwentytwo' ),
-	'categories' => array( 'headers' ),
+	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"backgroundColor":"primary","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-primary-background-color has-text-color has-background has-link-color" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->

--- a/inc/patterns/header-centered-title-navigation-social.php
+++ b/inc/patterns/header-centered-title-navigation-social.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Centered header with navigation, social links, and salmon background', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-headers' ),
+	'categories' => array( 'headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|primary"}}},"spacing":{"padding":{"top":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"backgroundColor":"secondary","textColor":"primary","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-primary-color has-secondary-background-color has-text-color has-background has-link-color" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->

--- a/inc/patterns/header-centered-title-navigation-social.php
+++ b/inc/patterns/header-centered-title-navigation-social.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Centered header with navigation, social links, and salmon background', 'twentytwentytwo' ),
-	'categories' => array( 'headers' ),
+	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|primary"}}},"spacing":{"padding":{"top":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"backgroundColor":"secondary","textColor":"primary","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-primary-color has-secondary-background-color has-text-color has-background has-link-color" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->

--- a/inc/patterns/header-default.php
+++ b/inc/patterns/header-default.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Default header', 'twentytwentytwo' ),
-	'categories' => array( 'headers' ),
+	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->

--- a/inc/patterns/header-default.php
+++ b/inc/patterns/header-default.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Default header', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-headers' ),
+	'categories' => array( 'headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->

--- a/inc/patterns/header-image-background-overlay.php
+++ b/inc/patterns/header-image-background-overlay.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Header with image background and overlay', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-headers' ),
+	'categories' => array( 'headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:cover {"url":"' . esc_url( get_template_directory_uri() ) . '/assets/images/ducks.jpg","dimRatio":90,"overlayColor":"primary","focalPoint":{"x":"0.26","y":"0.34"},"minHeight":100,"minHeightUnit":"px","contentPosition":"center center","align":"full","style":{"spacing":{"padding":{"top":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}},"color":{"duotone":["#000000","#ffffff"]}}} -->
 					<div class="wp-block-cover alignfull" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw);min-height:100px"><span aria-hidden="true" class="has-primary-background-color has-background-dim-90 wp-block-cover__gradient-background has-background-dim"></span><img class="wp-block-cover__image-background" alt="' . esc_attr__( 'Painting of ducks in the water.', 'twentytwentytwo' ) . '" src="' . esc_url( get_template_directory_uri() ) . '/assets/images/ducks.jpg" style="object-position:26% 34%" data-object-fit="cover" data-object-position="26% 34%"/><div class="wp-block-cover__inner-container"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"0rem","top":"0px","right":"0px","left":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"textColor":"background","layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/header-image-background-overlay.php
+++ b/inc/patterns/header-image-background-overlay.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Header with image background and overlay', 'twentytwentytwo' ),
-	'categories' => array( 'headers' ),
+	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:cover {"url":"' . esc_url( get_template_directory_uri() ) . '/assets/images/ducks.jpg","dimRatio":90,"overlayColor":"primary","focalPoint":{"x":"0.26","y":"0.34"},"minHeight":100,"minHeightUnit":"px","contentPosition":"center center","align":"full","style":{"spacing":{"padding":{"top":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}},"color":{"duotone":["#000000","#ffffff"]}}} -->
 					<div class="wp-block-cover alignfull" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw);min-height:100px"><span aria-hidden="true" class="has-primary-background-color has-background-dim-90 wp-block-cover__gradient-background has-background-dim"></span><img class="wp-block-cover__image-background" alt="' . esc_attr__( 'Painting of ducks in the water.', 'twentytwentytwo' ) . '" src="' . esc_url( get_template_directory_uri() ) . '/assets/images/ducks.jpg" style="object-position:26% 34%" data-object-fit="cover" data-object-position="26% 34%"/><div class="wp-block-cover__inner-container"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"0rem","top":"0px","right":"0px","left":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"textColor":"background","layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/header-image-background.php
+++ b/inc/patterns/header-image-background.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Header with image background', 'twentytwentytwo' ),
-	'categories' => array( 'headers' ),
+	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:cover {"url":"' . esc_url( get_template_directory_uri() ) . '/assets/images/flight-path-on-gray-c.jpg","dimRatio":0,"focalPoint":{"x":"0.58","y":"0.58"},"minHeight":400,"contentPosition":"center center","align":"full","style":{"spacing":{"padding":{"top":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)","bottom":"8rem","left":"max(1.25rem, 5vw)"}},"color":{}}} -->
 					<div class="wp-block-cover alignfull" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:8rem;padding-left:max(1.25rem, 5vw);min-height:400px"><span aria-hidden="true" class="has-background-dim-0 wp-block-cover__gradient-background has-background-dim"></span><img class="wp-block-cover__image-background" alt="' . esc_attr__( 'Illustration of a flying bird', 'twentytwentytwo' ) . '" src="' . esc_url( get_template_directory_uri() ) . '/assets/images/flight-path-on-gray-c.jpg" style="object-position:58% 58%" data-object-fit="cover" data-object-position="58% 58%"/><div class="wp-block-cover__inner-container"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"0rem","top":"0px","right":"0px","left":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}}},"textColor":"foreground","layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/header-image-background.php
+++ b/inc/patterns/header-image-background.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Header with image background', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-headers' ),
+	'categories' => array( 'headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:cover {"url":"' . esc_url( get_template_directory_uri() ) . '/assets/images/flight-path-on-gray-c.jpg","dimRatio":0,"focalPoint":{"x":"0.58","y":"0.58"},"minHeight":400,"contentPosition":"center center","align":"full","style":{"spacing":{"padding":{"top":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)","bottom":"8rem","left":"max(1.25rem, 5vw)"}},"color":{}}} -->
 					<div class="wp-block-cover alignfull" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:8rem;padding-left:max(1.25rem, 5vw);min-height:400px"><span aria-hidden="true" class="has-background-dim-0 wp-block-cover__gradient-background has-background-dim"></span><img class="wp-block-cover__image-background" alt="' . esc_attr__( 'Illustration of a flying bird', 'twentytwentytwo' ) . '" src="' . esc_url( get_template_directory_uri() ) . '/assets/images/flight-path-on-gray-c.jpg" style="object-position:58% 58%" data-object-fit="cover" data-object-position="58% 58%"/><div class="wp-block-cover__inner-container"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"0rem","top":"0px","right":"0px","left":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}}},"textColor":"foreground","layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/header-large-dark.php
+++ b/inc/patterns/header-large-dark.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Large header with dark background', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-headers' ),
+	'categories' => array( 'headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"8rem","right":"0px","left":"0px"},"margin":{"bottom":"8rem"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="margin-bottom:8rem;padding-top:0px;padding-right:0px;padding-bottom:8rem;padding-left:0px"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","top":"0px","bottom":"0px"}}},"layout":{"inherit":true}} -->

--- a/inc/patterns/header-large-dark.php
+++ b/inc/patterns/header-large-dark.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Large header with dark background', 'twentytwentytwo' ),
-	'categories' => array( 'headers' ),
+	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"8rem","right":"0px","left":"0px"},"margin":{"bottom":"8rem"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="margin-bottom:8rem;padding-top:0px;padding-right:0px;padding-bottom:8rem;padding-left:0px"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","top":"0px","bottom":"0px"}}},"layout":{"inherit":true}} -->

--- a/inc/patterns/header-logo-navigation-gray-background.php
+++ b/inc/patterns/header-logo-navigation-gray-background.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Logo and navigation header with gray background', 'twentytwentytwo' ),
-	'categories' => array( 'headers' ),
+	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}},"spacing":{"padding":{"top":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"backgroundColor":"secondary","textColor":"foreground","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-foreground-color has-secondary-background-color has-text-color has-background has-link-color" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"0rem","top":"0px","right":"0px","left":"0px"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/header-logo-navigation-gray-background.php
+++ b/inc/patterns/header-logo-navigation-gray-background.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Logo and navigation header with gray background', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-headers' ),
+	'categories' => array( 'headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}},"spacing":{"padding":{"top":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"backgroundColor":"secondary","textColor":"foreground","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-foreground-color has-secondary-background-color has-text-color has-background has-link-color" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"0rem","top":"0px","right":"0px","left":"0px"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/header-logo-navigation-offset-tagline.php
+++ b/inc/patterns/header-logo-navigation-offset-tagline.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Logo, navigation, and offset tagline Header', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-headers' ),
+	'categories' => array( 'headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem"}}}} -->
 					<div class="wp-block-group alignwide" style="padding-bottom:8rem"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/header-logo-navigation-offset-tagline.php
+++ b/inc/patterns/header-logo-navigation-offset-tagline.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Logo, navigation, and offset tagline Header', 'twentytwentytwo' ),
-	'categories' => array( 'headers' ),
+	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem"}}}} -->
 					<div class="wp-block-group alignwide" style="padding-bottom:8rem"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/header-logo-navigation-social-black-background.php
+++ b/inc/patterns/header-logo-navigation-social-black-background.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Logo, navigation, and social links header with black background', 'twentytwentytwo' ),
-	'categories' => array( 'headers' ),
+	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}},"spacing":{"padding":{"top":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"backgroundColor":"tertiary","textColor":"foreground","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-foreground-color has-tertiary-background-color has-text-color has-background has-link-color" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"0rem","top":"0px","right":"0px","left":"0px"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/header-logo-navigation-social-black-background.php
+++ b/inc/patterns/header-logo-navigation-social-black-background.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Logo, navigation, and social links header with black background', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-headers' ),
+	'categories' => array( 'headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}},"spacing":{"padding":{"top":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"backgroundColor":"tertiary","textColor":"foreground","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-foreground-color has-tertiary-background-color has-text-color has-background has-link-color" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"0rem","top":"0px","right":"0px","left":"0px"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/header-small-dark.php
+++ b/inc/patterns/header-small-dark.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Small header with dark background', 'twentytwentytwo' ),
-	'categories' => array( 'headers' ),
+	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"0px","right":"0px","left":"0px"},"margin":{"bottom":"8rem"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="margin-bottom:8rem;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","top":"0px","bottom":"0px"}}},"layout":{"inherit":true}} -->

--- a/inc/patterns/header-small-dark.php
+++ b/inc/patterns/header-small-dark.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Small header with dark background', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-headers' ),
+	'categories' => array( 'headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"0px","right":"0px","left":"0px"},"margin":{"bottom":"8rem"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="margin-bottom:8rem;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","top":"0px","bottom":"0px"}}},"layout":{"inherit":true}} -->

--- a/inc/patterns/header-stacked.php
+++ b/inc/patterns/header-stacked.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Logo and navigation header', 'twentytwentytwo' ),
-	'categories' => array( 'headers' ),
+	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-logo {"align":"center","width":128} /-->

--- a/inc/patterns/header-stacked.php
+++ b/inc/patterns/header-stacked.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Logo and navigation header', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-headers' ),
+	'categories' => array( 'headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-logo {"align":"center","width":128} /-->

--- a/inc/patterns/header-text-only-green-background.php
+++ b/inc/patterns/header-text-only-green-background.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Text-only header with green background', 'twentytwentytwo' ),
-	'categories' => array( 'headers' ),
+	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"backgroundColor":"primary","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-primary-background-color has-text-color has-background has-link-color" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/header-text-only-green-background.php
+++ b/inc/patterns/header-text-only-green-background.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Text-only header with green background', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-headers' ),
+	'categories' => array( 'headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"backgroundColor":"primary","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-primary-background-color has-text-color has-background has-link-color" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/header-text-only-salmon-background.php
+++ b/inc/patterns/header-text-only-salmon-background.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Text-only header with salmon background', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-headers' ),
+	'categories' => array( 'headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}},"spacing":{"padding":{"top":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"backgroundColor":"secondary","textColor":"foreground","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-foreground-color has-secondary-background-color has-text-color has-background has-link-color" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/header-text-only-salmon-background.php
+++ b/inc/patterns/header-text-only-salmon-background.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Text-only header with salmon background', 'twentytwentytwo' ),
-	'categories' => array( 'headers' ),
+	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}},"spacing":{"padding":{"top":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"backgroundColor":"secondary","textColor":"foreground","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-foreground-color has-secondary-background-color has-text-color has-background has-link-color" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/header-text-only-with-tagline-black-background.php
+++ b/inc/patterns/header-text-only-with-tagline-black-background.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Text-only header with tagline and black background', 'twentytwentytwo' ),
-	'categories' => array( 'headers' ),
+	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}},"spacing":{"padding":{"top":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"backgroundColor":"foreground","textColor":"secondary","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-secondary-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"0rem","top":"0px","right":"0px","left":"0px"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/header-text-only-with-tagline-black-background.php
+++ b/inc/patterns/header-text-only-with-tagline-black-background.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Text-only header with tagline and black background', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-headers' ),
+	'categories' => array( 'headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}},"spacing":{"padding":{"top":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"backgroundColor":"foreground","textColor":"secondary","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-secondary-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"0rem","top":"0px","right":"0px","left":"0px"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/header-title-and-button.php
+++ b/inc/patterns/header-title-and-button.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Title and button header', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-headers' ),
+	'categories' => array( 'headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}},"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->

--- a/inc/patterns/header-title-and-button.php
+++ b/inc/patterns/header-title-and-button.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Title and button header', 'twentytwentytwo' ),
-	'categories' => array( 'headers' ),
+	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}},"typography":{"fontStyle":"normal","fontWeight":"700"}}} /-->

--- a/inc/patterns/header-title-navigation-social.php
+++ b/inc/patterns/header-title-navigation-social.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Title, navigation, and social links header', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-headers' ),
+	'categories' => array( 'headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /-->

--- a/inc/patterns/header-title-navigation-social.php
+++ b/inc/patterns/header-title-navigation-social.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Title, navigation, and social links header', 'twentytwentytwo' ),
-	'categories' => array( 'headers' ),
+	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /-->

--- a/inc/patterns/header-with-tagline.php
+++ b/inc/patterns/header-with-tagline.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Header with tagline', 'twentytwentytwo' ),
-	'categories' => array( 'headers' ),
+	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->

--- a/inc/patterns/header-with-tagline.php
+++ b/inc/patterns/header-with-tagline.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Header with tagline', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-headers' ),
+	'categories' => array( 'headers' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"8rem","top":"max(1.25rem, 5vw)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:max(1.25rem, 5vw);padding-bottom:8rem"><!-- wp:group {"layout":{"type":"flex"}} -->

--- a/inc/patterns/page-about-large-image-and-buttons.php
+++ b/inc/patterns/page-about-large-image-and-buttons.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'About page with large image and buttons', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-pages' ),
+	'categories' => array( 'pages' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:image {"align":"full","sizeSlug":"full","linkDestination":"none"} -->
 					<figure class="wp-block-image alignfull size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/flight-path-on-gray-b.jpg" alt=""/></figure>

--- a/inc/patterns/page-about-large-image-and-buttons.php
+++ b/inc/patterns/page-about-large-image-and-buttons.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'About page with large image and buttons', 'twentytwentytwo' ),
-	'categories' => array( 'pages' ),
+	'categories' => array( 'pages', 'buttons' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:image {"align":"full","sizeSlug":"full","linkDestination":"none"} -->
 					<figure class="wp-block-image alignfull size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/flight-path-on-gray-b.jpg" alt=""/></figure>

--- a/inc/patterns/page-about-links-dark.php
+++ b/inc/patterns/page-about-links-dark.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'About page links (dark)', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-pages' ),
+	'categories' => array( 'pages' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"10rem","right":"max(1.25rem, 5vw)","bottom":"10rem","left":"max(1.25rem, 5vw)"}}},"backgroundColor":"primary","textColor":"background","layout":{"inherit":false,"contentSize":"400px"}} -->
 					<div class="wp-block-group alignfull has-background-color has-primary-background-color has-text-color has-background has-link-color" style="padding-top:10rem;padding-right:max(1.25rem, 5vw);padding-bottom:10rem;padding-left:max(1.25rem, 5vw)"><!-- wp:group -->
 					<div class="wp-block-group">

--- a/inc/patterns/page-about-links-dark.php
+++ b/inc/patterns/page-about-links-dark.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'About page links (dark)', 'twentytwentytwo' ),
-	'categories' => array( 'pages' ),
+	'categories' => array( 'pages', 'buttons' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"10rem","right":"max(1.25rem, 5vw)","bottom":"10rem","left":"max(1.25rem, 5vw)"}}},"backgroundColor":"primary","textColor":"background","layout":{"inherit":false,"contentSize":"400px"}} -->
 					<div class="wp-block-group alignfull has-background-color has-primary-background-color has-text-color has-background has-link-color" style="padding-top:10rem;padding-right:max(1.25rem, 5vw);padding-bottom:10rem;padding-left:max(1.25rem, 5vw)"><!-- wp:group -->
 					<div class="wp-block-group">

--- a/inc/patterns/page-about-links.php
+++ b/inc/patterns/page-about-links.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'About page links', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-pages' ),
+	'categories' => array( 'pages' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"10rem","right":"max(1.25rem, 5vw)","bottom":"10rem","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":false,"contentSize":"400px"}} -->
 					<div class="wp-block-group alignfull" style="padding-top:10rem;padding-right:max(1.25rem, 5vw);padding-bottom:10rem;padding-left:max(1.25rem, 5vw)"><!-- wp:image {"align":"center","width":100,"height":100,"sizeSlug":"full","linkDestination":"none","className":"is-style-rounded"} -->
 					<div class="wp-block-image is-style-rounded"><figure class="aligncenter size-full is-resized"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/icon-bird.jpg" alt="' . esc_attr__( 'Logo featuring a flying bird', 'twentytwentytwo' ) . '" width="100" height="100"/></figure></div>

--- a/inc/patterns/page-about-links.php
+++ b/inc/patterns/page-about-links.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'About page links', 'twentytwentytwo' ),
-	'categories' => array( 'pages' ),
+	'categories' => array( 'pages', 'buttons' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"10rem","right":"max(1.25rem, 5vw)","bottom":"10rem","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":false,"contentSize":"400px"}} -->
 					<div class="wp-block-group alignfull" style="padding-top:10rem;padding-right:max(1.25rem, 5vw);padding-bottom:10rem;padding-left:max(1.25rem, 5vw)"><!-- wp:image {"align":"center","width":100,"height":100,"sizeSlug":"full","linkDestination":"none","className":"is-style-rounded"} -->
 					<div class="wp-block-image is-style-rounded"><figure class="aligncenter size-full is-resized"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/icon-bird.jpg" alt="' . esc_attr__( 'Logo featuring a flying bird', 'twentytwentytwo' ) . '" width="100" height="100"/></figure></div>

--- a/inc/patterns/page-about-media-left.php
+++ b/inc/patterns/page-about-media-left.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'About page with media on the left', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-pages' ),
+	'categories' => array( 'pages' ),
 	'content'    => '<!-- wp:media-text {"align":"full","mediaType":"image","imageFill":true,"focalPoint":{"x":"0.63","y":"0.16"},"backgroundColor":"foreground","className":"alignfull is-image-fill has-background-color has-text-color has-background has-link-color"} -->
 					<div class="wp-block-media-text alignfull is-stacked-on-mobile is-image-fill has-background-color has-text-color has-background has-link-color has-foreground-background-color has-background"><figure class="wp-block-media-text__media" style="background-image:url(' . esc_url( get_template_directory_uri() ) . '/assets/images/bird-on-salmon.jpg);background-position:63% 16%"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/bird-on-salmon.jpg" alt="' . esc_attr__( 'Image of a bird on a branch', 'twentytwentytwo' ) . '"/></figure><div class="wp-block-media-text__content"><!-- wp:spacer {"height":32} -->
 					<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/inc/patterns/page-about-media-right.php
+++ b/inc/patterns/page-about-media-right.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'About page with media on the right', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-pages' ),
+	'categories' => array( 'pages' ),
 	'content'    => '<!-- wp:media-text {"align":"full","mediaPosition":"right","mediaLink":"' . esc_url( get_template_directory_uri() ) . '/assets/images/bird-on-black.jpg","mediaType":"image","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"foreground","textColor":"background"} -->
 				<div class="wp-block-media-text alignfull has-media-on-the-right is-stacked-on-mobile has-background-color has-foreground-background-color has-text-color has-background has-link-color"><figure class="wp-block-media-text__media"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/bird-on-black.jpg" alt="' . esc_attr__( 'An image of a bird flying', 'twentytwentytwo' ) . '"/></figure><div class="wp-block-media-text__content"><!-- wp:spacer {"height":32} -->
 					<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/inc/patterns/page-about-simple-dark.php
+++ b/inc/patterns/page-about-simple-dark.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Simple dark about page', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-pages' ),
+	'categories' => array( 'pages' ),
 	'content'    => '<!-- wp:cover {"overlayColor":"foreground","minHeight":100,"minHeightUnit":"vh","contentPosition":"center center","align":"full","style":{"spacing":{"padding":{"top":"max(1.25rem, 8vw)","right":"max(1.25rem, 8vw)","bottom":"max(1.25rem, 8vw)","left":"max(1.25rem, 8vw)"}}}} -->
 					<div class="wp-block-cover alignfull has-foreground-background-color has-background-dim" style="padding-top:max(1.25rem, 8vw);padding-right:max(1.25rem, 8vw);padding-bottom:max(1.25rem, 8vw);padding-left:max(1.25rem, 8vw);min-height:100vh"><div class="wp-block-cover__inner-container"><!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"},"overlayMenu":"always"} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->

--- a/inc/patterns/page-about-solid-color.php
+++ b/inc/patterns/page-about-solid-color.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'About page on solid color background', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-pages' ),
+	'categories' => array( 'pages' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"1.25rem","right":"1.25rem","bottom":"1.25rem","left":"1.25rem"}}}} -->
 					<div class="wp-block-group alignfull" style="padding-top:1.25rem;padding-right:1.25rem;padding-bottom:1.25rem;padding-left:1.25rem"><!-- wp:cover {"overlayColor":"secondary","minHeight":80,"minHeightUnit":"vh","isDark":false,"align":"full"} -->
 					<div class="wp-block-cover alignfull is-light" style="min-height:80vh"><span aria-hidden="true" class="has-secondary-background-color has-background-dim-100 wp-block-cover__gradient-background has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"inherit":false,"contentSize":"400px"}} -->

--- a/inc/patterns/page-layout-image-and-text.php
+++ b/inc/patterns/page-layout-image-and-text.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Page layout with image and text', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-pages' ),
+	'categories' => array( 'pages' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"8rem","bottom":"2rem","right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} -->
 				<div class="wp-block-group alignfull" style="padding-top:8rem;padding-right:max(1.25rem, 5vw);padding-bottom:2rem;padding-left:max(1.25rem, 5vw)"><!-- wp:heading {"align":"wide","style":{"typography":{"fontSize":"clamp(4rem, 8vw, 7.5rem)","lineHeight":"1.15","fontWeight":"300"}}} -->
 					<h2 class="alignwide" style="font-size:clamp(4rem, 8vw, 7.5rem);font-weight:300;line-height:1.15">' . wp_kses_post( __( '<em>Watching Birds </em><br><em>in the Garden</em>', 'twentytwentytwo' ) ) . '</h2>

--- a/inc/patterns/page-layout-image-text-and-video.php
+++ b/inc/patterns/page-layout-image-text-and-video.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Page layout with image, text and video', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-pages' ),
+	'categories' => array( 'pages' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"8rem","bottom":"8rem","left":"0px","right":"0px"}}},"backgroundColor":"primary","textColor":"background"} -->
 					<div class="wp-block-group alignfull has-background-color has-primary-background-color has-text-color has-background" style="padding-top:8rem;padding-bottom:8rem;padding-left:0px;padding-right:0px"><!-- wp:group {"align":"full","layout":{"inherit":true},"style":{"spacing":{"padding":{"left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}}} -->
 					<div class="wp-block-group alignfull" style="padding-left:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw)"><!-- wp:heading {"level":1,"align":"wide","style":{"typography":{"fontSize":"clamp(3rem, 6vw, 4.5rem)"}}} -->

--- a/inc/patterns/page-layout-two-columns.php
+++ b/inc/patterns/page-layout-two-columns.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Page layout with two columns', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-pages' ),
+	'categories' => array( 'pages' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"8rem","bottom":"8rem","right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-top:8rem;padding-right:max(1.25rem, 5vw);padding-bottom:8rem;padding-left:max(1.25rem, 5vw)"><!-- wp:heading {"level":1,"align":"wide","style":{"typography":{"fontSize":"clamp(4rem, 15vw, 12.5rem)","lineHeight":"1","fontWeight":"200"}}} -->
 					<h1 class="alignwide" style="font-size:clamp(4rem, 15vw, 12.5rem);font-weight:200;line-height:1">' . wp_kses_post( __( '<em>Goldfinch </em><br><em>&amp; Sparrow</em>', 'twentytwentytwo' ) ) . '</h1>

--- a/inc/patterns/page-sidebar-blog-posts-right.php
+++ b/inc/patterns/page-sidebar-blog-posts-right.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Blog posts with right sidebar', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-pages' ),
+	'categories' => array( 'pages' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"2rem","top":"0px","right":"0px","left":"0px"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:0px;padding-right:0px;padding-bottom:2rem;padding-left:0px"><!-- wp:group {"layout":{"type":"flex"}} -->

--- a/inc/patterns/page-sidebar-blog-posts.php
+++ b/inc/patterns/page-sidebar-blog-posts.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Blog posts with left sidebar', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-pages' ),
+	'categories' => array( 'pages' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:columns {"align":"wide","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"},"blockGap":"5%"},"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary"} -->
 					<div class="wp-block-columns alignwide has-primary-color has-text-color has-link-color" style="margin-top:0px;margin-bottom:0px"><!-- wp:column {"width":"33.33%"} -->

--- a/inc/patterns/page-sidebar-grid-posts.php
+++ b/inc/patterns/page-sidebar-grid-posts.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Grid of posts with left sidebar', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-pages' ),
+	'categories' => array( 'pages' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:columns {"align":"wide","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}}} -->
 					<div class="wp-block-columns alignwide" style="margin-top:0px;margin-bottom:0px"><!-- wp:column {"width":"30%"} -->

--- a/inc/patterns/page-sidebar-poster.php
+++ b/inc/patterns/page-sidebar-poster.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Poster with right sidebar', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-pages' ),
+	'categories' => array( 'pages' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":"5%"}}} -->
 					<div class="wp-block-columns alignwide"><!-- wp:column {"width":"70%"} -->

--- a/inc/patterns/query-default.php
+++ b/inc/patterns/query-default.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Default posts', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-query' ),
+	'categories' => array( 'query' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":""},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->

--- a/inc/patterns/query-default.php
+++ b/inc/patterns/query-default.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Default posts', 'twentytwentytwo' ),
-	'categories' => array( 'posts' ),
+	'categories' => array( 'query' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":""},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->

--- a/inc/patterns/query-default.php
+++ b/inc/patterns/query-default.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Default posts', 'twentytwentytwo' ),
-	'categories' => array( 'query' ),
+	'categories' => array( 'posts' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":""},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->

--- a/inc/patterns/query-grid.php
+++ b/inc/patterns/query-grid.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Grid of posts', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-query' ),
+	'categories' => array( 'query' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":12},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->

--- a/inc/patterns/query-grid.php
+++ b/inc/patterns/query-grid.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Grid of posts', 'twentytwentytwo' ),
-	'categories' => array( 'posts' ),
+	'categories' => array( 'query' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":12},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->

--- a/inc/patterns/query-grid.php
+++ b/inc/patterns/query-grid.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Grid of posts', 'twentytwentytwo' ),
-	'categories' => array( 'query' ),
+	'categories' => array( 'posts' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":12},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->

--- a/inc/patterns/query-image-grid.php
+++ b/inc/patterns/query-image-grid.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Grid of image posts', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-query' ),
+	'categories' => array( 'query' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":false,"perPage":12},"displayLayout":{"type":"flex","columns":3},"layout":{"inherit":true}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->

--- a/inc/patterns/query-image-grid.php
+++ b/inc/patterns/query-image-grid.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Grid of image posts', 'twentytwentytwo' ),
-	'categories' => array( 'query' ),
+	'categories' => array( 'posts' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":false,"perPage":12},"displayLayout":{"type":"flex","columns":3},"layout":{"inherit":true}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->

--- a/inc/patterns/query-image-grid.php
+++ b/inc/patterns/query-image-grid.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Grid of image posts', 'twentytwentytwo' ),
-	'categories' => array( 'posts' ),
+	'categories' => array( 'query' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":false,"perPage":12},"displayLayout":{"type":"flex","columns":3},"layout":{"inherit":true}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->

--- a/inc/patterns/query-irregular-grid.php
+++ b/inc/patterns/query-irregular-grid.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Irregular grid of posts', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-query' ),
+	'categories' => array( 'query' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:group {"align":"wide"} -->
 					<div class="wp-block-group alignwide"><!-- wp:columns {"align":"wide"} -->

--- a/inc/patterns/query-irregular-grid.php
+++ b/inc/patterns/query-irregular-grid.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Irregular grid of posts', 'twentytwentytwo' ),
-	'categories' => array( 'posts' ),
+	'categories' => array( 'query' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:group {"align":"wide"} -->
 					<div class="wp-block-group alignwide"><!-- wp:columns {"align":"wide"} -->

--- a/inc/patterns/query-irregular-grid.php
+++ b/inc/patterns/query-irregular-grid.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Irregular grid of posts', 'twentytwentytwo' ),
-	'categories' => array( 'query' ),
+	'categories' => array( 'posts' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:group {"align":"wide"} -->
 					<div class="wp-block-group alignwide"><!-- wp:columns {"align":"wide"} -->

--- a/inc/patterns/query-large-titles.php
+++ b/inc/patterns/query-large-titles.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Large post titles', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-query' ),
+	'categories' => array( 'query' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:query {"query":{"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"perPage":8},"align":"wide"} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template -->

--- a/inc/patterns/query-large-titles.php
+++ b/inc/patterns/query-large-titles.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Large post titles', 'twentytwentytwo' ),
-	'categories' => array( 'query' ),
+	'categories' => array( 'posts' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:query {"query":{"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"perPage":8},"align":"wide"} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template -->

--- a/inc/patterns/query-large-titles.php
+++ b/inc/patterns/query-large-titles.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Large post titles', 'twentytwentytwo' ),
-	'categories' => array( 'posts' ),
+	'categories' => array( 'query' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:query {"query":{"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"perPage":8},"align":"wide"} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template -->

--- a/inc/patterns/query-simple-blog.php
+++ b/inc/patterns/query-simple-blog.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Simple blog posts', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-query' ),
+	'categories' => array( 'query' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"perPage":10},"layout":{"inherit":true}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->

--- a/inc/patterns/query-simple-blog.php
+++ b/inc/patterns/query-simple-blog.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Simple blog posts', 'twentytwentytwo' ),
-	'categories' => array( 'posts' ),
+	'categories' => array( 'query' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"perPage":10},"layout":{"inherit":true}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->

--- a/inc/patterns/query-simple-blog.php
+++ b/inc/patterns/query-simple-blog.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Simple blog posts', 'twentytwentytwo' ),
-	'categories' => array( 'query' ),
+	'categories' => array( 'posts' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"perPage":10},"layout":{"inherit":true}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->

--- a/inc/patterns/query-text-grid.php
+++ b/inc/patterns/query-text-grid.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Text-based grid of posts', 'twentytwentytwo' ),
-	'categories' => array( 'twentytwentytwo-query' ),
+	'categories' => array( 'query' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":12},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->

--- a/inc/patterns/query-text-grid.php
+++ b/inc/patterns/query-text-grid.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Text-based grid of posts', 'twentytwentytwo' ),
-	'categories' => array( 'query' ),
+	'categories' => array( 'posts' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":12},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->

--- a/inc/patterns/query-text-grid.php
+++ b/inc/patterns/query-text-grid.php
@@ -4,7 +4,7 @@
  */
 return array(
 	'title'      => __( 'Text-based grid of posts', 'twentytwentytwo' ),
-	'categories' => array( 'posts' ),
+	'categories' => array( 'query' ),
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":12},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->


### PR DESCRIPTION
Resolves #267.

This PR moves our patterns over to the default categories whenever it makes sense to do so. We reuse the following categories that already exist in core: 

- Featured
- Headers
- Query
- Buttons
- Columns
- Gallery
- Text

... and we create just a couple additional ones: 

- Footers
- Pages

When our patterns appear in pre-existing categories, they appear at the top of the list. 

Some patterns appear in multiple categories, which I think is fine. 

Some of our patterns have `general` in their filename, even though that category isn't used anymore. I think that's ok though, it's essentially just like calling them "miscellaneous". Open to objections though. 🙂

## Screenshots

Before: 
<img width="1212" alt="Screen Shot 2021-12-09 at 1 01 05 PM" src="https://user-images.githubusercontent.com/1202812/145451637-b476f7f1-1d7a-45e8-bf2e-1e45a2d3d045.png">

After:

https://user-images.githubusercontent.com/1202812/145451797-bcd4e669-a580-4895-9bb7-c092959de024.mp4
