### PR TITLE
Add padding to post content in the editor

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -78,6 +78,15 @@ if ( ! function_exists( 'twentytwentytwo_editor_styles' ) ) :
 		// Add styles inline.
 		wp_add_inline_style( 'wp-block-library', twentytwentytwo_get_font_face_styles() );
 
+		// Apply padding only to content in the post editor.
+		// Needed until https://github.com/WordPress/gutenberg/pull/36214 is merged.
+		wp_add_inline_style(
+			'wp-block-library',
+			'.editor-styles-wrapper > .edit-post-visual-editor__post-title-wrapper, 
+			.editor-styles-wrapper > .edit-post-visual-editor__post-title-wrapper + .block-editor-block-list__layout {
+			padding: 0 var(--wp--custom--spacing--small, 1.25rem);
+		}'
+		);
 	}
 
 endif;


### PR DESCRIPTION
**Description**

This PR adds padding to the title and content in the post editor, so it matches the front-end. It partially addresses #234.

The main issue (aside from the fact that we are inlining the CSS in order to target the `.editor-styles-wrapper` class) with this approach is that it will apply padding even if you have the `Blank` template selected, which has no padding by default.

**Screenshots**

Editor | Front-end
------- | -------
<img width="1904" alt="Screen Shot 2021-12-09 at 12 21 27 PM" src="https://user-images.githubusercontent.com/5375500/145446518-4770ff6b-8ec9-4e83-9329-5a5d556f1e28.png"> | <img width="1904" alt="Screen Shot 2021-12-09 at 12 21 34 PM" src="https://user-images.githubusercontent.com/5375500/145446550-dd81dac1-e220-4390-94b1-64d5d2b7e51b.png">

**Testing Instructions** 

1. Create / edit a post or page that uses the default template. Verify content doesn't touch the edges of the screen.
2. Verify the padding matches the front-end.
3. Go to the site editor, verify no padding is applied.
