### PR TITLE
Remove unnecessary font weight rule font-weight rule from index and home templates

### DIFF
--- a/inc/patterns/query-default.php
+++ b/inc/patterns/query-default.php
@@ -9,7 +9,7 @@ return array(
 	'content'    => '<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":""},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
 					<!-- wp:group {"layout":{"inherit":true}} -->
-					<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","style":{"typography":{"fontStyle":"normal","fontWeight":"300"}},"fontSize":"huge"} /-->
+					<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"huge"} /-->
 
 					<!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"top":"calc(1.75 * var(--wp--style--block-gap))"}}}} /-->
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -6,7 +6,7 @@
 <!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"inherit":true},"tagName":"main"} -->
 <main class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","style":{"typography":{"fontStyle":"normal","fontWeight":"300"}},"fontSize":"huge"} /-->
+<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"huge"} /-->
 
 <!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"top":"calc(1.75 * var(--wp--style--block-gap))"}}}} /-->
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
 <!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"inherit":true},"tagName":"main"} -->
 <main class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","style":{"typography":{"fontStyle":"normal","fontWeight":"300"}},"fontSize":"huge"} /-->
+<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"huge"} /-->
 
 <!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"top":"calc(1.75 * var(--wp--style--block-gap))"}}}} /-->
 


### PR DESCRIPTION
This PR removes unnecessary font style + weight declarations from the `home.html` and `index.html` templates. These are unnecessary, because the same font weight rule is defined in theme.json already: 

https://github.com/WordPress/twentytwentytwo/blob/e9f49804eab30b51b9cd9b7d6b16674f80483b2c/theme.json#L232

... and `normal` is already the default value for this text anyway.

Removing these from the templates provides more flexibility in customization from child themes, and through `theme.json`. For example, [the "Swiss" variation in this PR](https://github.com/WordPress/theme-experiments/pull/292) tries to make all post titles bold. Before that rule was overridden here didn't work, but with this PR it works fine: 

Before|After
---|---
<img width="1124" alt="Screen Shot 2021-12-10 at 8 22 49 AM" src="https://user-images.githubusercontent.com/1202812/145581744-2a85089f-c269-40f8-b0ae-a4c311f0a821.png">|<img width="1123" alt="Screen Shot 2021-12-10 at 8 25 08 AM" src="https://user-images.githubusercontent.com/1202812/145581746-481b82e5-1b3e-4951-bf92-b6bdcf7d01a9.png">

There should be no appearance change by default, since these deleted rules exist already. 