### PR TITLE
Stop using H1 tags for the Site Title when it's in a footer pattern.

### DIFF
--- a/inc/patterns/footer-about-title-logo.php
+++ b/inc/patterns/footer-about-title-logo.php
@@ -21,7 +21,7 @@ return array(
 					<div style="height:180px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
-					<!-- wp:site-title /--></div>
+					<!-- wp:site-title {"level":0} /--></div>
 					<!-- /wp:column -->
 
 					<!-- wp:column {"verticalAlignment":"bottom"} -->

--- a/inc/patterns/footer-blog.php
+++ b/inc/patterns/footer-blog.php
@@ -40,7 +40,7 @@ return array(
 					<!-- /wp:spacer -->
 
 					<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title /-->
+					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title {"level":0} /-->
 
 					<!-- wp:paragraph {"align":"right"} -->
 					<p class="has-text-align-right">' .

--- a/inc/patterns/footer-dark.php
+++ b/inc/patterns/footer-dark.php
@@ -8,7 +8,7 @@ return array(
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<div class="wp-block-group alignwide"><!-- wp:site-title /-->
+					<div class="wp-block-group alignwide"><!-- wp:site-title {"level":0} /-->
 
 					<!-- wp:paragraph {"align":"right"} -->
 					<p class="has-text-align-right">' .

--- a/inc/patterns/footer-default.php
+++ b/inc/patterns/footer-default.php
@@ -8,7 +8,7 @@ return array(
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title /-->
+					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title {"level":0} /-->
 
 					<!-- wp:paragraph {"align":"right"} -->
 					<p class="has-text-align-right">' .

--- a/inc/patterns/footer-query-images-title-citation.php
+++ b/inc/patterns/footer-query-images-title-citation.php
@@ -24,7 +24,7 @@ return array(
 					<!-- /wp:spacer -->
 
 					<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title /-->
+					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title {"level":0} /-->
 					<!-- wp:group {"layout":{"type":"flex","justifyContent":"right"}} -->
 					<div class="wp-block-group">
 					<!-- wp:paragraph -->

--- a/inc/patterns/footer-query-title-citation.php
+++ b/inc/patterns/footer-query-title-citation.php
@@ -22,7 +22,7 @@ return array(
 					<!-- /wp:spacer -->
 
 					<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title /-->
+					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title {"level":0} /-->
 					<!-- wp:group {"layout":{"type":"flex","justifyContent":"right"}} -->
 					<div class="wp-block-group">
 					<!-- wp:paragraph -->


### PR DESCRIPTION
As raised by @sabernhardt in https://github.com/WordPress/twentytwentytwo/issues/233#issuecomment-991153100. 

All of Twenty Twenty-Two's footer patterns that included a Site Title were using the `H1` variation of it. This is unnecessary, since it's declared as a H1 above, and these are so far down the page anyway. This PR changes all the `H1`s to `p` tags instead. 