### PR TITLE
Fix alignment in footer blog pattern

### DIFF
--- a/inc/patterns/footer-blog.php
+++ b/inc/patterns/footer-blog.php
@@ -7,8 +7,8 @@ return array(
 	'categories' => array( 'footer' ),
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"8rem","bottom":"8rem"}}},"layout":{"inherit":true}} -->
-					<div class="wp-block-group alignfull" style="padding-top:8rem;padding-bottom:8rem"><!-- wp:columns -->
-					<div class="wp-block-columns"><!-- wp:column -->
+					<div class="wp-block-group alignfull" style="padding-top:8rem;padding-bottom:8rem"><!-- wp:columns {"align":"wide"} -->
+					<div class="wp-block-columns alignwide"><!-- wp:column -->
 					<div class="wp-block-column"><!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}}} -->
 					<p style="text-transform:uppercase">' . esc_html__( 'About us', 'twentytwentytwo' ) . '</p>
 					<!-- /wp:paragraph -->


### PR DESCRIPTION
The blog footer pattern is supposed to have its columns wide-aligned, but they're currently standard-width. This PR fixes that. 

Before|After
---|---
<img width="344" alt="Screen Shot 2021-12-14 at 10 06 04 AM" src="https://user-images.githubusercontent.com/1202812/146024358-ac41e80b-fa87-4ca6-9c79-092ad1b245a6.png">|<img width="342" alt="Screen Shot 2021-12-14 at 10 06 37 AM" src="https://user-images.githubusercontent.com/1202812/146024361-5cac18fd-3620-4d5c-b30d-3afd24e25e4d.png">

