### PR TITLE
Fix font size variable names for buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -67,7 +67,7 @@ a:active {
 	border-radius: 0;
 	border: none;
 	color: var(--wp--preset--color--background);
-	font-size: var(--wp--preset--typography--font-size--normal);
+	font-size: var(--wp--preset--font-size--normal);
 	padding: calc(.667em + 2px) calc(1.333em + 2px);
 }
 

--- a/theme.json
+++ b/theme.json
@@ -224,7 +224,7 @@
 					"text": "var(--wp--preset--color--background)"
 				},
 				"typography": {
-					"fontSize": "var(--wp--preset--typography--font-size--normal)"
+					"fontSize": "var(--wp--preset--font-size--normal)"
 				}
 			},
 			"core/post-title": {


### PR DESCRIPTION
Buttons are currently referencing the `--wp--preset--typography--font-size--normal` variable, but that doesn't exist. 😅 

This should be `--wp--preset--font-size--normal` instead. This shouldn't have any noticeable visual effect.

Before|After
---|---
<img width="258" alt="Screen Shot 2021-12-14 at 1 23 28 PM" src="https://user-images.githubusercontent.com/1202812/146057835-c9cfc382-bff1-4152-b1d1-7f73acaf14cc.png">|<img width="214" alt="Screen Shot 2021-12-14 at 1 26 28 PM" src="https://user-images.githubusercontent.com/1202812/146057841-94001d2c-2ced-4109-a8b5-78e5548a93be.png">
 