### PR TITLE
Try updated font sizes

### DIFF
--- a/inc/patterns/footer-query-images-title-citation.php
+++ b/inc/patterns/footer-query-images-title-citation.php
@@ -11,7 +11,7 @@ return array(
 					<div class="wp-block-query alignwide"><!-- wp:post-template -->
 					<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
-					<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+					<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
 
 					<!-- wp:post-excerpt /-->
 

--- a/inc/patterns/footer-query-title-citation.php
+++ b/inc/patterns/footer-query-title-citation.php
@@ -9,7 +9,7 @@ return array(
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"primary","textColor":"background","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull has-background-color has-primary-background-color has-text-color has-background has-link-color" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3},"align":"wide"} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template -->
-					<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+					<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
 
 					<!-- wp:post-excerpt /-->
 

--- a/inc/patterns/general-featured-posts.php
+++ b/inc/patterns/general-featured-posts.php
@@ -14,7 +14,7 @@ return array(
 					<div class="wp-block-query"><!-- wp:post-template -->
 					<!-- wp:post-featured-image {"isLink":true,"width":"","height":"310px"} /-->
 
-					<!-- wp:post-title {"isLink":true,"fontSize":"medium"} /-->
+					<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
 
 					<!-- wp:post-excerpt /-->
 

--- a/inc/patterns/general-large-list-names.php
+++ b/inc/patterns/general-large-list-names.php
@@ -17,8 +17,8 @@ return array(
 					<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
-					<!-- wp:paragraph {"style":{"typography":{"fontWeight":"300"}},"fontSize":"large"} -->
-					<p class="has-large-font-size" style="font-weight:300">' . esc_html__( 'Jesús Rodriguez, Doug Stilton, Emery Driscoll, Megan Perry, Rowan Price, Angelo Tso, Edward Stilton, Amy Jensen, Boston Bell, Shay Ford, Lee Cunningham, Evelynn Ray, Landen Reese, Ewan Hart, Jenna Chan, Phoenix Murray, Mel Saunders, Aldo Davidson, Zain Hall.', 'twentytwentytwo' ) . '</p>
+					<!-- wp:paragraph {"style":{"typography":{"fontWeight":"300"}},"fontSize":"x-large"} -->
+					<p class="has-x-large-font-size" style="font-weight:300">' . esc_html__( 'Jesús Rodriguez, Doug Stilton, Emery Driscoll, Megan Perry, Rowan Price, Angelo Tso, Edward Stilton, Amy Jensen, Boston Bell, Shay Ford, Lee Cunningham, Evelynn Ray, Landen Reese, Ewan Hart, Jenna Chan, Phoenix Murray, Mel Saunders, Aldo Davidson, Zain Hall.', 'twentytwentytwo' ) . '</p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:spacer {"height":32} -->

--- a/inc/patterns/general-list-events.php
+++ b/inc/patterns/general-list-events.php
@@ -7,8 +7,8 @@ return array(
 	'categories' => array( 'featured', 'text' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"8rem","bottom":"8rem","left":"0px","right":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"primary","textColor":"background"} -->
 					<div class="wp-block-group alignfull has-background-color has-primary-background-color has-text-color has-background has-link-color" style="padding-top:8rem;padding-right:0px;padding-bottom:8rem;padding-left:0px"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} -->
-					<div class="wp-block-group alignfull" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:heading {"align":"wide","style":{"typography":{"fontSize":"clamp(4rem, 8vw, 6.25rem)","lineHeight":"1.15"},"spacing":{"margin":{"bottom":"2rem"}}}} -->
-					<h2 class="alignwide" style="font-size:clamp(4rem, 8vw, 6.25rem);line-height:1.15;margin-bottom:2rem"><em>' . esc_html__( 'Speaker Series', 'twentytwentytwo' ) . '</em></h2>
+					<div class="wp-block-group alignfull" style="padding-right:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:heading {"align":"wide","style":{"typography":{"fontSize":"clamp(3.25rem, 8vw, 6.25rem)","lineHeight":"1.15"},"spacing":{"margin":{"bottom":"2rem"}}}} -->
+					<h2 class="alignwide" style="font-size:clamp(3.25rem, 8vw, 6.25rem);line-height:1.15;margin-bottom:2rem"><em>' . esc_html__( 'Speaker Series', 'twentytwentytwo' ) . '</em></h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:spacer {"height":32} -->

--- a/inc/patterns/general-list-events.php
+++ b/inc/patterns/general-list-events.php
@@ -27,8 +27,8 @@ return array(
 					<!-- /wp:column -->
 
 					<!-- wp:column {"verticalAlignment":"center"} -->
-					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:heading {"fontSize":"large"} -->
-					<h2 class="has-large-font-size" id="jesus-rodriguez">' . esc_html__( 'Jesús Rodriguez', 'twentytwentytwo' ) . '</h2>
+					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:heading {"fontSize":"x-large"} -->
+					<h2 class="has-x-large-font-size" id="jesus-rodriguez">' . esc_html__( 'Jesús Rodriguez', 'twentytwentytwo' ) . '</h2>
 					<!-- /wp:heading --></div>
 					<!-- /wp:column -->
 
@@ -51,8 +51,8 @@ return array(
 					<!-- /wp:column -->
 
 					<!-- wp:column {"verticalAlignment":"center"} -->
-					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:heading {"fontSize":"large"} -->
-					<h2 class="has-large-font-size" id="jesus-rodriguez">' . esc_html__( 'Doug Stilton', 'twentytwentytwo' ) . '</h2>
+					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:heading {"fontSize":"x-large"} -->
+					<h2 class="has-x-large-font-size" id="jesus-rodriguez">' . esc_html__( 'Doug Stilton', 'twentytwentytwo' ) . '</h2>
 					<!-- /wp:heading --></div>
 					<!-- /wp:column -->
 
@@ -75,8 +75,8 @@ return array(
 					<!-- /wp:column -->
 
 					<!-- wp:column {"verticalAlignment":"center"} -->
-					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:heading {"fontSize":"large"} -->
-					<h2 class="has-large-font-size" id="jesus-rodriguez">' . esc_html__( 'Amy Jensen', 'twentytwentytwo' ) . '</h2>
+					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:heading {"fontSize":"x-large"} -->
+					<h2 class="has-x-large-font-size" id="jesus-rodriguez">' . esc_html__( 'Amy Jensen', 'twentytwentytwo' ) . '</h2>
 					<!-- /wp:heading --></div>
 					<!-- /wp:column -->
 
@@ -99,8 +99,8 @@ return array(
 					<!-- /wp:column -->
 
 					<!-- wp:column {"verticalAlignment":"center"} -->
-					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:heading {"fontSize":"large"} -->
-					<h2 class="has-large-font-size" id="jesus-rodriguez">' . esc_html__( 'Emery Driscoll', 'twentytwentytwo' ) . '</h2>
+					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:heading {"fontSize":"x-large"} -->
+					<h2 class="has-x-large-font-size" id="jesus-rodriguez">' . esc_html__( 'Emery Driscoll', 'twentytwentytwo' ) . '</h2>
 					<!-- /wp:heading --></div>
 					<!-- /wp:column -->
 

--- a/inc/patterns/general-pricing-table.php
+++ b/inc/patterns/general-pricing-table.php
@@ -12,7 +12,7 @@ return array(
 					<!-- /wp:separator -->
 
 					<!-- wp:heading {"style":{"typography":{"fontSize":"var(--wp--custom--typography--font-size--gigantic, clamp(2.75rem, 6vw, 3.25rem))","lineHeight":"0.5"}}} -->
-					<h2 id="1" style="font-size:clamp(2.75rem, 6vw, 3.25rem);line-height:0.5">' . esc_html( _x( '1', 'First item in a numbered list.', 'twentytwentytwo' ) ) . '</h2>
+					<h2 id="1" style="font-size:var(--wp--custom--typography--font-size--gigantic, clamp(2.75rem, 6vw, 3.25rem));line-height:0.5">' . esc_html( _x( '1', 'First item in a numbered list.', 'twentytwentytwo' ) ) . '</h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:heading {"level":3,"fontSize":"x-large"} -->

--- a/inc/patterns/general-pricing-table.php
+++ b/inc/patterns/general-pricing-table.php
@@ -11,7 +11,7 @@ return array(
 					<hr class="wp-block-separator is-style-wide"/>
 					<!-- /wp:separator -->
 
-					<!-- wp:heading {"style":{"typography":{"fontSize":"clamp(2.75rem, 6vw, 3.25rem)","lineHeight":"0.5"}}} -->
+					<!-- wp:heading {"style":{"typography":{"fontSize":"var(--wp--custom--typography--font-size--gigantic, clamp(2.75rem, 6vw, 3.25rem))","lineHeight":"0.5"}}} -->
 					<h2 id="1" style="font-size:clamp(2.75rem, 6vw, 3.25rem);line-height:0.5">' . esc_html( _x( '1', 'First item in a numbered list.', 'twentytwentytwo' ) ) . '</h2>
 					<!-- /wp:heading -->
 

--- a/inc/patterns/general-pricing-table.php
+++ b/inc/patterns/general-pricing-table.php
@@ -15,8 +15,8 @@ return array(
 					<h2 id="1" style="font-size:clamp(3rem, 6vw, 4rem);line-height:0.5">' . esc_html( _x( '1', 'First item in a numbered list.', 'twentytwentytwo' ) ) . '</h2>
 					<!-- /wp:heading -->
 
-					<!-- wp:heading {"level":3,"fontSize":"large"} -->
-					<h3 class="has-large-font-size" id="pigeon"><em>' . esc_html__( 'Pigeon', 'twentytwentytwo' ) . '</em></h3>
+					<!-- wp:heading {"level":3,"fontSize":"x-large"} -->
+					<h3 class="has-x-large-font-size" id="pigeon"><em>' . esc_html__( 'Pigeon', 'twentytwentytwo' ) . '</em></h3>
 					<!-- /wp:heading -->
 
 					<!-- wp:paragraph -->
@@ -43,8 +43,8 @@ return array(
 					<h2 id="2" style="font-size:clamp(3rem, 6vw, 4rem);line-height:0.5">' . esc_html( _x( '2', 'Second item in a numbered list.', 'twentytwentytwo' ) ) . '</h2>
 					<!-- /wp:heading -->
 
-					<!-- wp:heading {"fontSize":"large"} -->
-					<h2 class="has-large-font-size" id="sparrow"><meta charset="utf-8"><em>' . esc_html__( 'Sparrow', 'twentytwentytwo' ) . '</em></h2>
+					<!-- wp:heading {"fontSize":"x-large"} -->
+					<h2 class="has-x-large-font-size" id="sparrow"><meta charset="utf-8"><em>' . esc_html__( 'Sparrow', 'twentytwentytwo' ) . '</em></h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:paragraph -->
@@ -71,8 +71,8 @@ return array(
 					<h2 id="3" style="font-size:clamp(3rem, 6vw, 4rem);line-height:0.5">' . esc_html( _x( '3', 'Third item in a numbered list.', 'twentytwentytwo' ) ) . '</h2>
 					<!-- /wp:heading -->
 
-					<!-- wp:heading {"fontSize":"large"} -->
-					<h2 class="has-large-font-size" id="falcon"><meta charset="utf-8"><em>' . esc_html__( 'Falcon', 'twentytwentytwo' ) . '</em></h2>
+					<!-- wp:heading {"fontSize":"x-large"} -->
+					<h2 class="has-x-large-font-size" id="falcon"><meta charset="utf-8"><em>' . esc_html__( 'Falcon', 'twentytwentytwo' ) . '</em></h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:paragraph -->

--- a/inc/patterns/general-pricing-table.php
+++ b/inc/patterns/general-pricing-table.php
@@ -11,8 +11,8 @@ return array(
 					<hr class="wp-block-separator is-style-wide"/>
 					<!-- /wp:separator -->
 
-					<!-- wp:heading {"style":{"typography":{"fontSize":"clamp(3rem, 6vw, 4rem)","lineHeight":"0.5"}}} -->
-					<h2 id="1" style="font-size:clamp(3rem, 6vw, 4rem);line-height:0.5">' . esc_html( _x( '1', 'First item in a numbered list.', 'twentytwentytwo' ) ) . '</h2>
+					<!-- wp:heading {"style":{"typography":{"fontSize":"clamp(2.75rem, 6vw, 3.25rem)","lineHeight":"0.5"}}} -->
+					<h2 id="1" style="font-size:clamp(2.75rem, 6vw, 3.25rem);line-height:0.5">' . esc_html( _x( '1', 'First item in a numbered list.', 'twentytwentytwo' ) ) . '</h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:heading {"level":3,"fontSize":"x-large"} -->
@@ -39,8 +39,8 @@ return array(
 					<hr class="wp-block-separator is-style-wide"/>
 					<!-- /wp:separator -->
 
-					<!-- wp:heading {"style":{"typography":{"fontSize":"clamp(3rem, 6vw, 4rem)","lineHeight":"0.5"}}} -->
-					<h2 id="2" style="font-size:clamp(3rem, 6vw, 4rem);line-height:0.5">' . esc_html( _x( '2', 'Second item in a numbered list.', 'twentytwentytwo' ) ) . '</h2>
+					<!-- wp:heading {"style":{"typography":{"fontSize":"clamp(2.75rem, 6vw, 3.25rem)","lineHeight":"0.5"}}} -->
+					<h2 id="2" style="font-size:clamp(2.75rem, 6vw, 3.25rem);line-height:0.5">' . esc_html( _x( '2', 'Second item in a numbered list.', 'twentytwentytwo' ) ) . '</h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:heading {"fontSize":"x-large"} -->
@@ -67,8 +67,8 @@ return array(
 					<hr class="wp-block-separator is-style-wide"/>
 					<!-- /wp:separator -->
 
-					<!-- wp:heading {"style":{"typography":{"fontSize":"clamp(3rem, 6vw, 4rem)","lineHeight":"0.5"}}} -->
-					<h2 id="3" style="font-size:clamp(3rem, 6vw, 4rem);line-height:0.5">' . esc_html( _x( '3', 'Third item in a numbered list.', 'twentytwentytwo' ) ) . '</h2>
+					<!-- wp:heading {"style":{"typography":{"fontSize":"clamp(2.75rem, 6vw, 3.25rem)","lineHeight":"0.5"}}} -->
+					<h2 id="3" style="font-size:clamp(2.75rem, 6vw, 3.25rem);line-height:0.5">' . esc_html( _x( '3', 'Third item in a numbered list.', 'twentytwentytwo' ) ) . '</h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:heading {"fontSize":"x-large"} -->

--- a/inc/patterns/general-subscribe.php
+++ b/inc/patterns/general-subscribe.php
@@ -12,8 +12,8 @@ return array(
 					<!-- /wp:heading -->
 
 					<!-- wp:buttons -->
-					<div class="wp-block-buttons"><!-- wp:button {"fontSize":"normal"} -->
-					<div class="wp-block-button has-custom-font-size has-normal-font-size"><a class="wp-block-button__link">' . esc_html__( 'Join our mailing list', 'twentytwentytwo' ) . '</a></div>
+					<div class="wp-block-buttons"><!-- wp:button {"fontSize":"medium"} -->
+					<div class="wp-block-button has-custom-font-size has-medium-font-size"><a class="wp-block-button__link">' . esc_html__( 'Join our mailing list', 'twentytwentytwo' ) . '</a></div>
 					<!-- /wp:button --></div>
 					<!-- /wp:buttons --></div>
 					<!-- /wp:column -->

--- a/inc/patterns/general-two-images-text.php
+++ b/inc/patterns/general-two-images-text.php
@@ -21,8 +21,8 @@ return array(
 					<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
-					<!-- wp:heading {"fontSize":"large"} -->
-					<h2 class="has-large-font-size" id="screening">' . esc_html__( 'SCREENING', 'twentytwentytwo' ) . '</h2>
+					<!-- wp:heading {"fontSize":"x-large"} -->
+					<h2 class="has-x-large-font-size" id="screening">' . esc_html__( 'SCREENING', 'twentytwentytwo' ) . '</h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:paragraph -->

--- a/inc/patterns/general-video-trailer.php
+++ b/inc/patterns/general-video-trailer.php
@@ -8,8 +8,8 @@ return array(
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}},"spacing":{"padding":{"top":"6rem","right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","bottom":"4rem"}}},"backgroundColor":"secondary","textColor":"foreground","layout":{"inherit":true}} -->
 				<div class="wp-block-group alignfull has-foreground-color has-secondary-background-color has-text-color has-background has-link-color" style="padding-top:6rem;padding-right:max(1.25rem, 5vw);padding-bottom:4rem;padding-left:max(1.25rem, 5vw)"><!-- wp:columns {"align":"wide"} -->
 				<div class="wp-block-columns alignwide"><!-- wp:column {"width":"33.33%"} -->
-				<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:heading {"fontSize":"large"} -->
-				<h2 class="has-large-font-size" id="extended-trailer">' . esc_html__( 'Extended Trailer', 'twentytwentytwo' ) . '</h2>
+				<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:heading {"fontSize":"x-large"} -->
+				<h2 class="has-x-large-font-size" id="extended-trailer">' . esc_html__( 'Extended Trailer', 'twentytwentytwo' ) . '</h2>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph -->

--- a/inc/patterns/general-wide-image-intro-buttons.php
+++ b/inc/patterns/general-wide-image-intro-buttons.php
@@ -12,8 +12,8 @@ return array(
 
 				<!-- wp:columns {"verticalAlignment":null} -->
 				<div class="wp-block-columns"><!-- wp:column {"verticalAlignment":"bottom"} -->
-				<div class="wp-block-column is-vertically-aligned-bottom"><!-- wp:heading {"style":{"typography":{"fontSize":"clamp(4rem, 8vw, 6.25rem)","lineHeight":"1.15"}}} -->
-				<h2 style="font-size:clamp(4rem, 8vw, 6.25rem);line-height:1.15"><em>' . wp_kses_post( __( 'Welcome to<br>the Aviary', 'twentytwentytwo' ) ) . '</em></h2>
+				<div class="wp-block-column is-vertically-aligned-bottom"><!-- wp:heading {"style":{"typography":{"fontSize":"clamp(3.25rem, 8vw, 6.25rem)","lineHeight":"1.15"}}} -->
+				<h2 style="font-size:clamp(3.25rem, 8vw, 6.25rem);line-height:1.15"><em>' . wp_kses_post( __( 'Welcome to<br>the Aviary', 'twentytwentytwo' ) ) . '</em></h2>
 				<!-- /wp:heading --></div>
 				<!-- /wp:column -->
 

--- a/inc/patterns/header-large-dark.php
+++ b/inc/patterns/header-large-dark.php
@@ -20,8 +20,8 @@ return array(
 					<!-- /wp:navigation --></div>
 					<!-- /wp:group -->
 
-					<!-- wp:heading {"align":"wide","style":{"typography":{"fontSize":"clamp(4rem, 8vw, 6.25rem)","lineHeight":"1.15"}}} -->
-					<h2 class="alignwide" style="font-size:clamp(4rem, 8vw, 6.25rem);line-height:1.15">' . wp_kses_post( __( '<em>The Hatchery</em>: a blog about my adventures in bird watching', 'twentytwentytwo' ) ) . '</h2>
+					<!-- wp:heading {"align":"wide","style":{"typography":{"fontSize":"clamp(3.25rem, 8vw, 6.25rem)","lineHeight":"1.15"}}} -->
+					<h2 class="alignwide" style="font-size:clamp(3.25rem, 8vw, 6.25rem);line-height:1.15">' . wp_kses_post( __( '<em>The Hatchery</em>: a blog about my adventures in bird watching', 'twentytwentytwo' ) ) . '</h2>
 					<!-- /wp:heading --></div>
 					<!-- /wp:group -->
 

--- a/inc/patterns/hidden-heading-and-bird.php
+++ b/inc/patterns/hidden-heading-and-bird.php
@@ -10,8 +10,8 @@ return array(
 	'title'    => __( 'Heading and bird image', 'twentytwentytwo' ),
 	'inserter' => false,
 	'content'  => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","top":"0px","bottom":"0px"}}},"layout":{"inherit":true}} -->
-					<div class="wp-block-group alignfull" style="padding-top:0px;padding-right:max(1.25rem, 5vw);padding-bottom:0px;padding-left:max(1.25rem, 5vw)"><!-- wp:heading {"align":"wide","style":{"typography":{"fontSize":"clamp(4rem, 8vw, 6.25rem)","lineHeight":"1.15"}}} -->
-					<h2 class="alignwide" style="font-size:clamp(4rem, 8vw, 6.25rem);line-height:1.15">' . wp_kses_post( __( '<em>The Hatchery</em>: a blog about my adventures in bird watching', 'twentytwentytwo' ) ) . '</h2>
+					<div class="wp-block-group alignfull" style="padding-top:0px;padding-right:max(1.25rem, 5vw);padding-bottom:0px;padding-left:max(1.25rem, 5vw)"><!-- wp:heading {"align":"wide","style":{"typography":{"fontSize":"clamp(3.25rem, 8vw, 6.25rem)","lineHeight":"1.15"}}} -->
+					<h2 class="alignwide" style="font-size:clamp(3.25rem, 8vw, 6.25rem);line-height:1.15">' . wp_kses_post( __( '<em>The Hatchery</em>: a blog about my adventures in bird watching', 'twentytwentytwo' ) ) . '</h2>
 					<!-- /wp:heading --></div>
 					<!-- /wp:group -->
 

--- a/inc/patterns/hidden-heading-and-bird.php
+++ b/inc/patterns/hidden-heading-and-bird.php
@@ -10,8 +10,8 @@ return array(
 	'title'    => __( 'Heading and bird image', 'twentytwentytwo' ),
 	'inserter' => false,
 	'content'  => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)","top":"0px","bottom":"0px"}}},"layout":{"inherit":true}} -->
-					<div class="wp-block-group alignfull" style="padding-top:0px;padding-right:max(1.25rem, 5vw);padding-bottom:0px;padding-left:max(1.25rem, 5vw)"><!-- wp:heading {"align":"wide","style":{"typography":{"fontSize":"clamp(3.25rem, 8vw, 6.25rem)","lineHeight":"1.15"}}} -->
-					<h2 class="alignwide" style="font-size:clamp(3.25rem, 8vw, 6.25rem);line-height:1.15">' . wp_kses_post( __( '<em>The Hatchery</em>: a blog about my adventures in bird watching', 'twentytwentytwo' ) ) . '</h2>
+					<div class="wp-block-group alignfull" style="padding-top:0px;padding-right:max(1.25rem, 5vw);padding-bottom:0px;padding-left:max(1.25rem, 5vw)"><!-- wp:heading {"align":"wide","style":{"typography":{"fontSize":"var(--wp--custom--typography--font-size--colossal, clamp(3.25rem, 8vw, 6.25rem))","lineHeight":"1.15"}}} -->
+					<h2 class="alignwide" style="font-size:var(--wp--custom--typography--font-size--colossal, clamp(3.25rem, 8vw, 6.25rem));line-height:1.15">' . wp_kses_post( __( '<em>The Hatchery</em>: a blog about my adventures in bird watching', 'twentytwentytwo' ) ) . '</h2>
 					<!-- /wp:heading --></div>
 					<!-- /wp:group -->
 

--- a/inc/patterns/page-about-links-dark.php
+++ b/inc/patterns/page-about-links-dark.php
@@ -13,8 +13,8 @@ return array(
 					<figure class="wp-block-image size-full is-resized is-style-rounded"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/icon-bird.jpg" alt="' . esc_attr__( 'Logo featuring a flying bird', 'twentytwentytwo' ) . '" width="100" height="100"/></figure>
 					<!-- /wp:image -->
 
-					<!-- wp:heading {"textAlign":"left","style":{"typography":{"fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))"}}} -->
-					<h2 class="has-text-align-left" style="font-size:var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))">' . esc_html__( 'A trouble of hummingbirds', 'twentytwentytwo' ) . '</h2>
+					<!-- wp:heading {"textAlign":"left","style":{"typography":{"fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.25rem, 4vw, 2.75rem))"}}} -->
+					<h2 class="has-text-align-left" style="font-size:var(--wp--custom--typography--font-size--huge, clamp(2.25rem, 4vw, 2.75rem))">' . esc_html__( 'A trouble of hummingbirds', 'twentytwentytwo' ) . '</h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:spacer {"height":40} -->

--- a/inc/patterns/page-about-links-dark.php
+++ b/inc/patterns/page-about-links-dark.php
@@ -13,8 +13,8 @@ return array(
 					<figure class="wp-block-image size-full is-resized is-style-rounded"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/icon-bird.jpg" alt="' . esc_attr__( 'Logo featuring a flying bird', 'twentytwentytwo' ) . '" width="100" height="100"/></figure>
 					<!-- /wp:image -->
 
-					<!-- wp:heading {"textAlign":"left","fontSize":"huge"} -->
-					<h2 class="has-text-align-left has-huge-font-size">' . esc_html__( 'A trouble of hummingbirds', 'twentytwentytwo' ) . '</h2>
+					<!-- wp:heading {"textAlign":"left","style":{"typography":{"fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))"}}} -->
+					<h2 class="has-text-align-left" style="font-size:var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))">' . esc_html__( 'A trouble of hummingbirds', 'twentytwentytwo' ) . '</h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:spacer {"height":40} -->

--- a/inc/patterns/page-about-links.php
+++ b/inc/patterns/page-about-links.php
@@ -11,8 +11,10 @@ return array(
 					<!-- /wp:image -->
 
 					<!-- wp:group -->
-					<div class="wp-block-group"><!-- wp:heading {"textAlign":"center","fontSize":"huge"} -->
-					<h2 class="has-text-align-center has-huge-font-size" id="swoop-1">' . esc_html__( 'Swoop', 'twentytwentytwo' ) . '</h2>
+					<div class="wp-block-group">
+
+					<!-- wp:heading {"textAlign":"center","style":{"typography":{"fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))"}}} -->
+					<h2 class="has-text-align-center" style="font-size:var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))">' . esc_html__( 'Swoop', 'twentytwentytwo' ) . '</h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:paragraph {"align":"center"} -->

--- a/inc/patterns/page-about-links.php
+++ b/inc/patterns/page-about-links.php
@@ -13,8 +13,8 @@ return array(
 					<!-- wp:group -->
 					<div class="wp-block-group">
 
-					<!-- wp:heading {"textAlign":"center","style":{"typography":{"fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))"}}} -->
-					<h2 class="has-text-align-center" style="font-size:var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))">' . esc_html__( 'Swoop', 'twentytwentytwo' ) . '</h2>
+					<!-- wp:heading {"textAlign":"center","style":{"typography":{"fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.25rem, 4vw, 2.75rem))"}}} -->
+					<h2 class="has-text-align-center" style="font-size:var(--wp--custom--typography--font-size--huge, clamp(2.25rem, 4vw, 2.75rem))">' . esc_html__( 'Swoop', 'twentytwentytwo' ) . '</h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:paragraph {"align":"center"} -->

--- a/inc/patterns/page-about-solid-color.php
+++ b/inc/patterns/page-about-solid-color.php
@@ -10,8 +10,8 @@ return array(
 					<div class="wp-block-cover alignfull is-light" style="min-height:80vh"><span aria-hidden="true" class="has-secondary-background-color has-background-dim-100 wp-block-cover__gradient-background has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"inherit":false,"contentSize":"400px"}} -->
 					<div class="wp-block-group"><!-- wp:spacer {"height":64} -->
 					<div style="height:64px" aria-hidden="true" class="wp-block-spacer"></div>
-					<!-- /wp:spacer --><!-- wp:heading {"style":{"typography":{"lineHeight":"1","textTransform":"uppercase","fontSize":"clamp(3rem, 6vw, 4rem)"}}} -->
-					<h2 id="edvard-smith" style="font-size:clamp(3rem, 6vw, 4rem);line-height:1;text-transform:uppercase">' . wp_kses_post( __( 'Edvard<br>Smith', 'twentytwentytwo' ) ) . '</h2>
+					<!-- /wp:spacer --><!-- wp:heading {"style":{"typography":{"lineHeight":"1","textTransform":"uppercase","fontSize":"clamp(2.75rem, 6vw, 3.25rem)"}}} -->
+					<h2 id="edvard-smith" style="font-size:clamp(2.75rem, 6vw, 3.25rem);line-height:1;text-transform:uppercase">' . wp_kses_post( __( 'Edvard<br>Smith', 'twentytwentytwo' ) ) . '</h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:spacer {"height":8} -->

--- a/inc/patterns/page-layout-image-text-and-video.php
+++ b/inc/patterns/page-layout-image-text-and-video.php
@@ -17,8 +17,8 @@ return array(
 
 					<!-- wp:columns {"align":"wide"} -->
 					<div class="wp-block-columns alignwide"><!-- wp:column {"width":"33.33%"} -->
-					<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:heading {"fontSize":"large"} -->
-					<h2 class="has-large-font-size">' . esc_html__( 'Screening', 'twentytwentytwo' ) . '</h2>
+					<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:heading {"fontSize":"x-large"} -->
+					<h2 class="has-x-large-font-size">' . esc_html__( 'Screening', 'twentytwentytwo' ) . '</h2>
 					<!-- /wp:heading -->
 					
 					<!-- wp:paragraph -->
@@ -45,8 +45,8 @@ return array(
 					<!-- wp:group {"align":"full","layout":{"inherit":true},"style":{"spacing":{"padding":{"left":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)"}}}} -->
 					<div class="wp-block-group alignfull" style="padding-left:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw)"><!-- wp:columns {"align":"wide"} -->
 					<div class="wp-block-columns alignwide"><!-- wp:column {"width":"33.33%"} -->
-					<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:heading {"fontSize":"large"} -->
-					<h2 class="has-large-font-size">' . esc_html__( 'Extended Trailer', 'twentytwentytwo' ) . '</h2>
+					<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:heading {"fontSize":"x-large"} -->
+					<h2 class="has-x-large-font-size">' . esc_html__( 'Extended Trailer', 'twentytwentytwo' ) . '</h2>
 					<!-- /wp:heading -->
 					
 					<!-- wp:paragraph -->

--- a/inc/patterns/page-sidebar-blog-posts-right.php
+++ b/inc/patterns/page-sidebar-blog-posts-right.php
@@ -62,7 +62,7 @@ return array(
 					<div style="height:4px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
-					<!-- wp:site-title {"isLink":false,"style":{"typography":{"fontStyle":"normal","fontWeight":"300","lineHeight":"1.2"}},"fontSize":"medium","fontFamily":"source-serif-pro"} /-->
+					<!-- wp:site-title {"isLink":false,"style":{"typography":{"fontStyle":"normal","fontWeight":"300","lineHeight":"1.2"}},"fontSize":"large","fontFamily":"source-serif-pro"} /-->
 
 					<!-- wp:site-tagline /-->
 
@@ -70,14 +70,14 @@ return array(
 					<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
-					<!-- wp:heading {"level":4,"fontSize":"medium"} -->
-					<h4 class="has-medium-font-size"><em>' . esc_html__( 'Categories', 'twentytwentytwo' ) . '</em></h4>
+					<!-- wp:heading {"level":4,"fontSize":"large"} -->
+					<h4 class="has-large-font-size"><em>' . esc_html__( 'Categories', 'twentytwentytwo' ) . '</em></h4>
 					<!-- /wp:heading -->
 
 					<!-- wp:tag-cloud {"taxonomy":"category","showTagCounts":true} /-->
 
-					<!-- wp:heading {"level":4,"fontSize":"medium"} -->
-					<h4 class="has-medium-font-size"><em>' . esc_html__( 'Tags', 'twentytwentytwo' ) . '</em></h4>
+					<!-- wp:heading {"level":4,"fontSize":"large"} -->
+					<h4 class="has-large-font-size"><em>' . esc_html__( 'Tags', 'twentytwentytwo' ) . '</em></h4>
 					<!-- /wp:heading -->
 
 					<!-- wp:tag-cloud {"showTagCounts":true} /--></div>

--- a/inc/patterns/page-sidebar-blog-posts-right.php
+++ b/inc/patterns/page-sidebar-blog-posts-right.php
@@ -24,7 +24,7 @@ return array(
 					<div class="wp-block-columns alignwide has-foreground-color has-text-color has-link-color" style="margin-top:0px;margin-bottom:0px"><!-- wp:column {"width":"66.66%","style":{"spacing":{"padding":{"bottom":"6rem"}}}} -->
 					<div class="wp-block-column" style="padding-bottom:6rem;flex-basis:66.66%"><!-- wp:query {"queryId":9,"query":{"perPage":"5","pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"layout":{"inherit":true}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->
-					<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"0","bottom":"1rem"}},"typography":{"fontStyle":"normal","fontWeight":"300"},"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}}},"textColor":"foreground","fontSize":"huge"} /-->
+					<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"0","bottom":"1rem"}},"typography":{"fontStyle":"normal","fontWeight":"300"},"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}}},"textColor":"foreground","fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))"} /-->
 
 					<!-- wp:post-featured-image {"isLink":true} /-->
 

--- a/inc/patterns/page-sidebar-blog-posts-right.php
+++ b/inc/patterns/page-sidebar-blog-posts-right.php
@@ -24,7 +24,7 @@ return array(
 					<div class="wp-block-columns alignwide has-foreground-color has-text-color has-link-color" style="margin-top:0px;margin-bottom:0px"><!-- wp:column {"width":"66.66%","style":{"spacing":{"padding":{"bottom":"6rem"}}}} -->
 					<div class="wp-block-column" style="padding-bottom:6rem;flex-basis:66.66%"><!-- wp:query {"queryId":9,"query":{"perPage":"5","pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"layout":{"inherit":true}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->
-					<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"0","bottom":"1rem"}},"typography":{"fontStyle":"normal","fontWeight":"300"},"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}}},"textColor":"foreground","fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))"} /-->
+					<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"0","bottom":"1rem"}},"typography":{"fontStyle":"normal","fontWeight":"300"},"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}}},"textColor":"foreground","fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.25rem, 4vw, 2.75rem))"} /-->
 
 					<!-- wp:post-featured-image {"isLink":true} /-->
 

--- a/inc/patterns/page-sidebar-blog-posts.php
+++ b/inc/patterns/page-sidebar-blog-posts.php
@@ -46,7 +46,7 @@ return array(
 					<!-- wp:column {"width":"66.66%"} -->
 					<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:query {"query":{"perPage":"5","pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"layout":{"inherit":true}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->
-					<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"0","bottom":"1rem"}},"typography":{"fontStyle":"normal","fontWeight":"300"},"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary","fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))"} /-->
+					<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"0","bottom":"1rem"}},"typography":{"fontStyle":"normal","fontWeight":"300"},"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary","fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.25rem, 4vw, 2.75rem))"} /-->
 
 					<!-- wp:post-featured-image {"isLink":true} /-->
 

--- a/inc/patterns/page-sidebar-blog-posts.php
+++ b/inc/patterns/page-sidebar-blog-posts.php
@@ -46,7 +46,7 @@ return array(
 					<!-- wp:column {"width":"66.66%"} -->
 					<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:query {"query":{"perPage":"5","pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"layout":{"inherit":true}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->
-					<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"0","bottom":"1rem"}},"typography":{"fontStyle":"normal","fontWeight":"300"},"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary","fontSize":"huge"} /-->
+					<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"0","bottom":"1rem"}},"typography":{"fontStyle":"normal","fontWeight":"300"},"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary","fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))"} /-->
 
 					<!-- wp:post-featured-image {"isLink":true} /-->
 

--- a/inc/patterns/page-sidebar-grid-posts.php
+++ b/inc/patterns/page-sidebar-grid-posts.php
@@ -8,7 +8,7 @@ return array(
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:columns {"align":"wide","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}}} -->
 					<div class="wp-block-columns alignwide" style="margin-top:0px;margin-bottom:0px"><!-- wp:column {"width":"30%"} -->
-					<div class="wp-block-column" style="flex-basis:30%"><!-- wp:site-title {"isLink":false,"style":{"spacing":{"margin":{"top":"0px","bottom":"1rem"}},"typography":{"fontStyle":"italic","fontWeight":"300","lineHeight":"1.1"}},"fontSize":"huge","fontFamily":"source-serif-pro"} /-->
+					<div class="wp-block-column" style="flex-basis:30%"><!-- wp:site-title {"isLink":false,"style":{"spacing":{"margin":{"top":"0px","bottom":"1rem"}},"typography":{"fontStyle":"italic","fontWeight":"300","lineHeight":"1.1"}},"fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))","fontFamily":"source-serif-pro"} /-->
 
 					<!-- wp:site-tagline {"fontSize":"small"} /-->
 

--- a/inc/patterns/page-sidebar-grid-posts.php
+++ b/inc/patterns/page-sidebar-grid-posts.php
@@ -8,7 +8,7 @@ return array(
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"max(1.25rem, 5vw)","right":"max(1.25rem, 5vw)","bottom":"max(1.25rem, 5vw)","left":"max(1.25rem, 5vw)"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-top:max(1.25rem, 5vw);padding-right:max(1.25rem, 5vw);padding-bottom:max(1.25rem, 5vw);padding-left:max(1.25rem, 5vw)"><!-- wp:columns {"align":"wide","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}}} -->
 					<div class="wp-block-columns alignwide" style="margin-top:0px;margin-bottom:0px"><!-- wp:column {"width":"30%"} -->
-					<div class="wp-block-column" style="flex-basis:30%"><!-- wp:site-title {"isLink":false,"style":{"spacing":{"margin":{"top":"0px","bottom":"1rem"}},"typography":{"fontStyle":"italic","fontWeight":"300","lineHeight":"1.1"}},"fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))","fontFamily":"source-serif-pro"} /-->
+					<div class="wp-block-column" style="flex-basis:30%"><!-- wp:site-title {"isLink":false,"style":{"spacing":{"margin":{"top":"0px","bottom":"1rem"}},"typography":{"fontStyle":"italic","fontWeight":"300","lineHeight":"1.1"}},"fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.25rem, 4vw, 2.75rem))","fontFamily":"source-serif-pro"} /-->
 
 					<!-- wp:site-tagline {"fontSize":"small"} /-->
 

--- a/inc/patterns/page-sidebar-poster.php
+++ b/inc/patterns/page-sidebar-poster.php
@@ -36,8 +36,8 @@ return array(
 					<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
-					<!-- wp:heading {"level":3,"fontSize":"medium"} -->
-					<h3 class="has-medium-font-size"><em>' . esc_html__( 'Date', 'twentytwentytwo' ) . '</em></h3>
+					<!-- wp:heading {"level":3,"fontSize":"large"} -->
+					<h3 class="has-large-font-size"><em>' . esc_html__( 'Date', 'twentytwentytwo' ) . '</em></h3>
 					<!-- /wp:heading -->
 
 					<!-- wp:paragraph -->
@@ -48,8 +48,8 @@ return array(
 					<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
-					<!-- wp:heading {"level":3,"fontSize":"medium"} -->
-					<h3 class="has-medium-font-size"><em>' . esc_html__( 'Location', 'twentytwentytwo' ) . '</em></h3>
+					<!-- wp:heading {"level":3,"fontSize":"large"} -->
+					<h3 class="has-large-font-size"><em>' . esc_html__( 'Location', 'twentytwentytwo' ) . '</em></h3>
 					<!-- /wp:heading -->
 
 					<!-- wp:paragraph -->

--- a/inc/patterns/query-default.php
+++ b/inc/patterns/query-default.php
@@ -9,7 +9,7 @@ return array(
 	'content'    => '<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":""},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
 					<!-- wp:group {"layout":{"inherit":true}} -->
-					<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))"} /-->
+					<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.25rem, 4vw, 2.75rem))"} /-->
 
 					<!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"top":"calc(1.75 * var(--wp--style--block-gap))"}}}} /-->
 

--- a/inc/patterns/query-default.php
+++ b/inc/patterns/query-default.php
@@ -9,7 +9,7 @@ return array(
 	'content'    => '<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":""},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
 					<!-- wp:group {"layout":{"inherit":true}} -->
-					<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"huge"} /-->
+					<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))"} /-->
 
 					<!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"top":"calc(1.75 * var(--wp--style--block-gap))"}}}} /-->
 

--- a/inc/patterns/query-grid.php
+++ b/inc/patterns/query-grid.php
@@ -10,7 +10,7 @@ return array(
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
 					<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
-					<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+					<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
 
 					<!-- wp:post-excerpt /-->
 

--- a/inc/patterns/query-irregular-grid.php
+++ b/inc/patterns/query-irregular-grid.php
@@ -13,7 +13,7 @@ return array(
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
 					<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
-					<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+					<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
 
 					<!-- wp:post-excerpt /-->
 
@@ -31,7 +31,7 @@ return array(
 
 					<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
-					<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+					<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
 
 					<!-- wp:post-excerpt /-->
 
@@ -49,7 +49,7 @@ return array(
 
 					<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
-					<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+					<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
 
 					<!-- wp:post-excerpt /-->
 
@@ -65,7 +65,7 @@ return array(
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
 					<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
-					<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+					<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
 
 					<!-- wp:post-excerpt /-->
 
@@ -83,7 +83,7 @@ return array(
 
 					<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
-					<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+					<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
 
 					<!-- wp:post-excerpt /-->
 
@@ -101,7 +101,7 @@ return array(
 
 					<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
-					<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+					<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
 
 					<!-- wp:post-excerpt /-->
 
@@ -121,7 +121,7 @@ return array(
 
 					<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
-					<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+					<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
 
 					<!-- wp:post-excerpt /-->
 
@@ -139,7 +139,7 @@ return array(
 
 					<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
-					<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+					<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
 
 					<!-- wp:post-excerpt /-->
 
@@ -157,7 +157,7 @@ return array(
 
 					<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
-					<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+					<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
 
 					<!-- wp:post-excerpt /-->
 

--- a/inc/patterns/query-large-titles.php
+++ b/inc/patterns/query-large-titles.php
@@ -14,7 +14,7 @@ return array(
 					<!-- /wp:column -->
 
 					<!-- wp:column {"verticalAlignment":"center","width":""} -->
-					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}},"typography":{"fontSize":"clamp(3rem, 6vw, 4rem)"}}} /--></div>
+					<div class="wp-block-column is-vertically-aligned-center"><!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}},"typography":{"fontSize":"clamp(2.75rem, 6vw, 3.25rem)"}}} /--></div>
 					<!-- /wp:column --></div>
 					<!-- /wp:columns -->
 

--- a/inc/patterns/query-simple-blog.php
+++ b/inc/patterns/query-simple-blog.php
@@ -8,7 +8,7 @@ return array(
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"perPage":10},"layout":{"inherit":true}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->
-					<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}},"typography":{"fontStyle":"normal","fontWeight":"300"},"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary","fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))"} /-->
+					<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}},"typography":{"fontStyle":"normal","fontWeight":"300"},"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary","fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.25rem, 4vw, 2.75rem))"} /-->
 
 					<!-- wp:post-featured-image {"isLink":true} /-->
 

--- a/inc/patterns/query-simple-blog.php
+++ b/inc/patterns/query-simple-blog.php
@@ -8,7 +8,7 @@ return array(
 	'blockTypes' => array( 'core/query' ),
 	'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"perPage":10},"layout":{"inherit":true}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->
-					<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}},"typography":{"fontStyle":"normal","fontWeight":"300"},"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary","fontSize":"huge"} /-->
+					<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}},"typography":{"fontStyle":"normal","fontWeight":"300"},"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary","fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))"} /-->
 
 					<!-- wp:post-featured-image {"isLink":true} /-->
 

--- a/inc/patterns/query-text-grid.php
+++ b/inc/patterns/query-text-grid.php
@@ -9,7 +9,7 @@ return array(
 	'content'    => '<!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":12},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
 
-					<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+					<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
 
 					<!-- wp:post-excerpt /-->
 

--- a/style.css
+++ b/style.css
@@ -67,7 +67,7 @@ a:active {
 	border-radius: 0;
 	border: none;
 	color: var(--wp--preset--color--background);
-	font-size: var(--wp--preset--typography--font-size--medium);
+	font-size: var(--wp--preset--font-size--medium);
 	padding: calc(.667em + 2px) calc(1.333em + 2px);
 }
 

--- a/style.css
+++ b/style.css
@@ -67,7 +67,7 @@ a:active {
 	border-radius: 0;
 	border: none;
 	color: var(--wp--preset--color--background);
-	font-size: var(--wp--preset--typography--font-size--normal);
+	font-size: var(--wp--preset--typography--font-size--medium);
 	padding: calc(.667em + 2px) calc(1.333em + 2px);
 }
 

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -5,7 +5,7 @@
 
 <!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"main","align":"wide","layout":{"inherit":false}} -->
 <main class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
-<!-- wp:post-title {"isLink":true,"align":"wide","style":{"typography":{"fontStyle":"normal","fontWeight":"300"}},"fontSize":"huge"} /-->
+<!-- wp:post-title {"isLink":true,"align":"wide","style":{"typography":{"fontStyle":"normal","fontWeight":"300"}},"fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))"} /-->
 
 <!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"top":"calc(1.75 * var(--wp--style--block-gap))"}}}} /-->
 

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -1,11 +1,11 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:query-title {"type":"archive","align":"wide","style":{"typography":{"fontSize":"clamp(3rem, 6vw, 4rem)"},"spacing":{"margin":{"bottom":"6rem"}}}} /-->
+<div class="wp-block-group"><!-- wp:query-title {"type":"archive","align":"wide","style":{"typography":{"fontSize":"clamp(2.75rem, 6vw, 3.25rem)"},"spacing":{"margin":{"bottom":"6rem"}}}} /-->
 
 <!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"main","align":"wide","layout":{"inherit":false}} -->
 <main class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
-<!-- wp:post-title {"isLink":true,"align":"wide","style":{"typography":{"fontStyle":"normal","fontWeight":"300"}},"fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))"} /-->
+<!-- wp:post-title {"isLink":true,"align":"wide","style":{"typography":{"fontStyle":"normal","fontWeight":"300"}},"fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.25rem, 4vw, 2.75rem))"} /-->
 
 <!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"top":"calc(1.75 * var(--wp--style--block-gap))"}}}} /-->
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -3,7 +3,7 @@
 <!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"inherit":true},"tagName":"main"} -->
 <main class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"huge"} /-->
+<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))"} /-->
 
 <!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"top":"calc(1.75 * var(--wp--style--block-gap))"}}}} /-->
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -3,7 +3,7 @@
 <!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"inherit":true},"tagName":"main"} -->
 <main class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))"} /-->
+<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.25rem, 4vw, 2.75rem))"} /-->
 
 <!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"top":"calc(1.75 * var(--wp--style--block-gap))"}}}} /-->
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
 <!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"inherit":true},"tagName":"main"} -->
 <main class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"huge"} /-->
+<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))"} /-->
 
 <!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"top":"calc(1.75 * var(--wp--style--block-gap))"}}}} /-->
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
 <!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"inherit":true},"tagName":"main"} -->
 <main class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.5rem, 4vw, 3rem))"} /-->
+<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"var(--wp--custom--typography--font-size--huge, clamp(2.25rem, 4vw, 2.75rem))"} /-->
 
 <!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"top":"calc(1.75 * var(--wp--style--block-gap))"}}}} /-->
 

--- a/theme.json
+++ b/theme.json
@@ -220,7 +220,7 @@
 					"text": "var(--wp--preset--color--background)"
 				},
 				"typography": {
-					"fontSize": "var(--wp--preset--typography--font-size--medium)"
+					"fontSize": "var(--wp--preset--font-size--medium)"
 				}
 			},
 			"core/post-title": {

--- a/theme.json
+++ b/theme.json
@@ -145,9 +145,9 @@
 			},
 			"typography": {
 				"font-size": {
-					"huge": "clamp(2.5rem, 4vw, 3rem)",
-					"gigantic": "clamp(3rem, 6vw, 4rem)",
-					"colossal": "clamp(4rem, 8vw, 6.25rem)"
+					"huge": "clamp(2.25rem, 4vw, 2.75rem)",
+					"gigantic": "clamp(2.75rem, 6vw, 3.25rem)",
+					"colossal": "clamp(3.25rem, 8vw, 6.25rem)"
 				},
 				"line-height": {
 					"tiny": 1.15,

--- a/theme.json
+++ b/theme.json
@@ -145,6 +145,7 @@
 			},
 			"typography": {
 				"font-size": {
+					"huge": "clamp(2.5rem, 4vw, 3rem)",
 					"gigantic": "clamp(3rem, 6vw, 4rem)",
 					"colossal": "clamp(4rem, 8vw, 6.25rem)"
 				},
@@ -187,24 +188,19 @@
 					"slug": "small"
 				},
 				{
-					"name": "Normal",
-					"size": "1.125rem",
-					"slug": "normal"
-				},
-				{
 					"name": "Medium",
-					"size": "1.75rem",
+					"size": "1.125rem",
 					"slug": "medium"
 				},
 				{
 					"name": "Large",
-					"size": "clamp(1.75rem, 3vw, 2.25rem)",
+					"size": "1.75rem",
 					"slug": "large"
 				},
 				{
-					"name": "Huge",
-					"size": "clamp(2.5rem, 4vw, 3rem)",
-					"slug": "huge"
+					"name": "Extra Large",
+					"size": "clamp(1.75rem, 3vw, 2.25rem)",
+					"slug": "x-large"
 				}
 			]
 		},
@@ -224,7 +220,7 @@
 					"text": "var(--wp--preset--color--background)"
 				},
 				"typography": {
-					"fontSize": "var(--wp--preset--typography--font-size--normal)"
+					"fontSize": "var(--wp--preset--typography--font-size--medium)"
 				}
 			},
 			"core/post-title": {
@@ -264,7 +260,7 @@
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--system-font)",
 					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-					"fontSize": "var(--wp--preset--font-size--normal)",
+					"fontSize": "var(--wp--preset--font-size--medium)",
 					"fontWeight": "normal"
 				}
 			}
@@ -295,7 +291,7 @@
 					"fontFamily": "var(--wp--preset--font-family--source-serif-pro)",
 					"fontWeight": "300",
 					"lineHeight": "var(--wp--custom--typography--line-height--tiny)",
-					"fontSize": "var(--wp--preset--font-size--huge)"
+					"fontSize": "var(--wp--custom--typography--font-size--huge)"
 				}
 			},
 			"h4": {
@@ -303,7 +299,7 @@
 					"fontFamily": "var(--wp--preset--font-family--source-serif-pro)",
 					"fontWeight": "300",
 					"lineHeight": "var(--wp--custom--typography--line-height--tiny)",
-					"fontSize": "var(--wp--preset--font-size--large)"
+					"fontSize": "var(--wp--preset--font-size--x-large)"
 				}
 			},
 			"h5": {
@@ -312,7 +308,7 @@
 					"fontWeight": "700",
 					"textTransform": "uppercase",
 					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-					"fontSize": "var(--wp--preset--font-size--normal)"
+					"fontSize": "var(--wp--preset--font-size--medium)"
 				}
 			},
 			"h6": {
@@ -321,7 +317,7 @@
 					"fontWeight": "400",
 					"textTransform": "uppercase",
 					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-					"fontSize": "var(--wp--preset--font-size--normal)"
+					"fontSize": "var(--wp--preset--font-size--medium)"
 				}
 			},
 			"link": {
@@ -336,7 +332,7 @@
 		"typography": {
 			"fontFamily": "var(--wp--preset--font-family--system-font)",
 			"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-			"fontSize": "var(--wp--preset--font-size--normal)"
+			"fontSize": "var(--wp--preset--font-size--medium)"
 		}
 	},
 	"templateParts": [

--- a/theme.json
+++ b/theme.json
@@ -183,22 +183,18 @@
 			],
 			"fontSizes": [
 				{
-					"name": "Small",
 					"size": "1rem",
 					"slug": "small"
 				},
 				{
-					"name": "Medium",
 					"size": "1.125rem",
 					"slug": "medium"
 				},
 				{
-					"name": "Large",
 					"size": "1.75rem",
 					"slug": "large"
 				},
 				{
-					"name": "Extra Large",
 					"size": "clamp(1.75rem, 3vw, 2.25rem)",
 					"slug": "x-large"
 				}


### PR DESCRIPTION
This PR changes our font sizes a bit, to align with the upcoming [font-size changes in Core](https://github.com/WordPress/gutenberg/pull/37381), and the work being done in https://github.com/WordPress/gutenberg/pull/37038. 

For Twenty Twenty-Two's purposes, we had to rename some of the size slugs: The "Normal" font size can't just be dropped outright since it's the base size used for the entire theme. So I changed that to Medium, and scaled things up from there. Here are the changes: 

Old preset sizes:

- Small
- Normal
- Medium
- Large
- Huge

New preset sizes:

- Small
- Medium
- Large
- Extra Large

Changes: 

- Small  ➡️ _(no change)_
- Normal ➡️ Medium
- Medium ➡️ Large
- Large ➡️ Extra Large
- Huge ➡️ _(custom variable, same name)_
