### PR TITLE
Fix query padding

### DIFF
--- a/style.css
+++ b/style.css
@@ -96,7 +96,7 @@ a:active {
  */
 
 .wp-site-blocks,
-.is-root-container,
+body > .is-root-container,
 .edit-post-visual-editor__post-title-wrapper,
 .wp-block-group.alignfull,
 .is-root-container .wp-block[data-align="full"] > .wp-block-group {


### PR DESCRIPTION
As noted in https://github.com/WordPress/twentytwentytwo/pull/291#discussion_r768784280, de-selected query items currently appear with some additional left/right padding. Note the second item in the list here: 

Current|Indended
---|---
<img width="1364" alt="Screen Shot 2021-12-14 at 2 35 14 PM" src="https://user-images.githubusercontent.com/1202812/146067501-608ffc9f-6249-4d50-9f9c-2ca6b8c47492.png">|<img width="1365" alt="Screen Shot 2021-12-14 at 2 32 36 PM" src="https://user-images.githubusercontent.com/1202812/146067502-a0fd0ee5-d132-468d-869f-078c14275d6e.png">


This will eventually be addressed upstream I believe (https://github.com/WordPress/gutenberg/issues/33248), but if we want, we can easily fix this with a simple specificity change in Twenty Twenty-Two's layout CSS.