### PR TITLE
Add menu container padding

### DIFF
--- a/style.css
+++ b/style.css
@@ -124,7 +124,9 @@ body > .is-root-container,
 
 /*
  * Responsive menu container padding.
- * This gives the responsive container the same padding as the site itself.
+ * This ensures the responsive container inherits the same
+ * spacing defined above. This behavior may be built into
+ * the Block Editor in the future.
  */
 
 .wp-block-navigation__responsive-container.is-menu-open {

--- a/style.css
+++ b/style.css
@@ -121,3 +121,16 @@ body > .is-root-container,
 	margin-right: auto !important;
 	width: inherit;
 }
+
+/*
+ * Responsive menu container padding.
+ * This gives the responsive container the same padding as the site itself.
+ */
+
+.wp-block-navigation__responsive-container.is-menu-open {
+	padding-top: var(--wp--custom--spacing--outer);
+	padding-bottom: var(--wp--custom--spacing--large);
+	padding-right: var(--wp--custom--spacing--outer);
+	padding-left: var(--wp--custom--spacing--outer);
+}
+


### PR DESCRIPTION
Closes #292 (It's not perfect, but it's the best we can do at the moment)

This PR modifies the default padding for the menu container so that it is in sync with with the site's outer padding. 

This means that (if you use the default header, have a one-line title, and have no site logo), the close button will probably line up with the menu button. But even without that set of specific circumstances, I think this is a reasonable move so that the outer spacing matches the site. 

Before|After
---|---
![space-old](https://user-images.githubusercontent.com/1202812/146236425-5d08c125-f789-4453-9578-239dbeb4c04e.gif)|![space](https://user-images.githubusercontent.com/1202812/146236432-df680ee1-d352-488d-8be4-2d8fcee0fca6.gif)

