### PR TITLE
Update Query Loop patterns with less posts per page

### DIFF
--- a/inc/patterns/page-sidebar-blog-posts-right.php
+++ b/inc/patterns/page-sidebar-blog-posts-right.php
@@ -22,7 +22,7 @@ return array(
 
 					<!-- wp:columns {"align":"wide","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"},"blockGap":"5%"},"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}}},"textColor":"foreground"} -->
 					<div class="wp-block-columns alignwide has-foreground-color has-text-color has-link-color" style="margin-top:0px;margin-bottom:0px"><!-- wp:column {"width":"66.66%","style":{"spacing":{"padding":{"bottom":"6rem"}}}} -->
-					<div class="wp-block-column" style="padding-bottom:6rem;flex-basis:66.66%"><!-- wp:query {"queryId":9,"query":{"perPage":"5","pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"layout":{"inherit":true}} -->
+					<div class="wp-block-column" style="padding-bottom:6rem;flex-basis:66.66%"><!-- wp:query {"queryId":9,"query":{"perPage":"3","pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"layout":{"inherit":true}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->
 					<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"0","bottom":"1rem"}},"typography":{"fontStyle":"normal","fontWeight":"300"},"elements":{"link":{"color":{"text":"var:preset|color|foreground"}}}},"textColor":"foreground","fontSize":"huge"} /-->
 

--- a/inc/patterns/page-sidebar-blog-posts.php
+++ b/inc/patterns/page-sidebar-blog-posts.php
@@ -44,7 +44,7 @@ return array(
 					<!-- /wp:column -->
 
 					<!-- wp:column {"width":"66.66%"} -->
-					<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:query {"query":{"perPage":"5","pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"layout":{"inherit":true}} -->
+					<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:query {"query":{"perPage":"3","pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"layout":{"inherit":true}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->
 					<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"0","bottom":"1rem"}},"typography":{"fontStyle":"normal","fontWeight":"300"},"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary","fontSize":"huge"} /-->
 

--- a/inc/patterns/page-sidebar-grid-posts.php
+++ b/inc/patterns/page-sidebar-grid-posts.php
@@ -48,7 +48,7 @@ return array(
 					<!-- /wp:column -->
 
 					<!-- wp:column {"width":"70%"} -->
-					<div class="wp-block-column" style="flex-basis:70%"><!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":false,"perPage":12},"displayLayout":{"type":"flex","columns":3},"layout":{"inherit":true}} -->
+					<div class="wp-block-column" style="flex-basis:70%"><!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":false,"perPage":6},"displayLayout":{"type":"flex","columns":3},"layout":{"inherit":true}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->
 					<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"200px"} /-->
 

--- a/inc/patterns/query-default.php
+++ b/inc/patterns/query-default.php
@@ -6,7 +6,7 @@ return array(
 	'title'      => __( 'Default posts', 'twentytwentytwo' ),
 	'categories' => array( 'query' ),
 	'blockTypes' => array( 'core/query' ),
-	'content'    => '<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":""},"align":"wide","layout":{"inherit":true}} -->
+	'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":""},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
 					<!-- wp:group {"layout":{"inherit":true}} -->
 					<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"huge"} /-->

--- a/inc/patterns/query-grid.php
+++ b/inc/patterns/query-grid.php
@@ -6,7 +6,7 @@ return array(
 	'title'      => __( 'Grid of posts', 'twentytwentytwo' ),
 	'categories' => array( 'query' ),
 	'blockTypes' => array( 'core/query' ),
-	'content'    => '<!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":12},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
+	'content'    => '<!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":3},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
 					<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 

--- a/inc/patterns/query-image-grid.php
+++ b/inc/patterns/query-image-grid.php
@@ -6,7 +6,7 @@ return array(
 	'title'      => __( 'Grid of image posts', 'twentytwentytwo' ),
 	'categories' => array( 'query' ),
 	'blockTypes' => array( 'core/query' ),
-	'content'    => '<!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":false,"perPage":12},"displayLayout":{"type":"flex","columns":3},"layout":{"inherit":true}} -->
+	'content'    => '<!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":false,"perPage":3},"displayLayout":{"type":"flex","columns":3},"layout":{"inherit":true}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->
 					<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"200px"} /-->
 

--- a/inc/patterns/query-irregular-grid.php
+++ b/inc/patterns/query-irregular-grid.php
@@ -9,7 +9,7 @@ return array(
 	'content'    => '<!-- wp:group {"align":"wide"} -->
 					<div class="wp-block-group alignwide"><!-- wp:columns {"align":"wide"} -->
 					<div class="wp-block-columns alignwide"><!-- wp:column -->
-					<div class="wp-block-column"><!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"displayLayout":{"type":"list","columns":3},"align":"wide","layout":{"inherit":true}} -->
+					<div class="wp-block-column"><!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
 					<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
@@ -23,7 +23,7 @@ return array(
 					<!-- /wp:column -->
 
 					<!-- wp:column -->
-					<div class="wp-block-column"><!-- wp:query {"query":{"offset":"1","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"displayLayout":{"type":"list","columns":3},"align":"wide","layout":{"inherit":true}} -->
+					<div class="wp-block-column"><!-- wp:query {"query":{"offset":"1","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
 					<!-- wp:spacer {"height":64} -->
 					<div style="height:64px" aria-hidden="true" class="wp-block-spacer"></div>
@@ -41,7 +41,7 @@ return array(
 					<!-- /wp:column -->
 
 					<!-- wp:column -->
-					<div class="wp-block-column"><!-- wp:query {"query":{"offset":"2","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"displayLayout":{"type":"list","columns":3},"align":"wide","layout":{"inherit":true}} -->
+					<div class="wp-block-column"><!-- wp:query {"query":{"offset":"2","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
 					<!-- wp:spacer {"height":128} -->
 					<div style="height:128px" aria-hidden="true" class="wp-block-spacer"></div>
@@ -61,7 +61,7 @@ return array(
 
 					<!-- wp:columns {"align":"wide"} -->
 					<div class="wp-block-columns alignwide"><!-- wp:column -->
-					<div class="wp-block-column"><!-- wp:query {"query":{"offset":"3","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"displayLayout":{"type":"list","columns":3},"align":"wide","layout":{"inherit":true}} -->
+					<div class="wp-block-column"><!-- wp:query {"query":{"offset":"3","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
 					<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
@@ -75,7 +75,7 @@ return array(
 					<!-- /wp:column -->
 
 					<!-- wp:column -->
-					<div class="wp-block-column"><!-- wp:query {"query":{"offset":"4","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"displayLayout":{"type":"list","columns":3},"align":"wide","layout":{"inherit":true}} -->
+					<div class="wp-block-column"><!-- wp:query {"query":{"offset":"4","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
 					<!-- wp:spacer {"height":96} -->
 					<div style="height:96px" aria-hidden="true" class="wp-block-spacer"></div>
@@ -93,66 +93,10 @@ return array(
 					<!-- /wp:column -->
 
 					<!-- wp:column -->
-					<div class="wp-block-column"><!-- wp:query {"query":{"offset":"5","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"displayLayout":{"type":"list","columns":3},"align":"wide","layout":{"inherit":true}} -->
+					<div class="wp-block-column"><!-- wp:query {"query":{"offset":"5","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
 					<!-- wp:spacer {"height":160} -->
 					<div style="height:160px" aria-hidden="true" class="wp-block-spacer"></div>
-					<!-- /wp:spacer -->
-
-					<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
-
-					<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
-
-					<!-- wp:post-excerpt /-->
-
-					<!-- wp:post-date {"format":"F j, Y","isLink":true,"fontSize":"small"} /-->
-					<!-- /wp:post-template --></div>
-					<!-- /wp:query --></div>
-					<!-- /wp:column --></div>
-					<!-- /wp:columns -->
-
-					<!-- wp:columns {"align":"wide"} -->
-					<div class="wp-block-columns alignwide"><!-- wp:column -->
-					<div class="wp-block-column"><!-- wp:query {"query":{"offset":"6","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"displayLayout":{"type":"list","columns":3},"align":"wide","layout":{"inherit":true}} -->
-					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
-					<!-- wp:spacer {"height":32} -->
-					<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
-					<!-- /wp:spacer -->
-
-					<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
-
-					<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
-
-					<!-- wp:post-excerpt /-->
-
-					<!-- wp:post-date {"format":"F j, Y","isLink":true,"fontSize":"small"} /-->
-					<!-- /wp:post-template --></div>
-					<!-- /wp:query --></div>
-					<!-- /wp:column -->
-
-					<!-- wp:column -->
-					<div class="wp-block-column"><!-- wp:query {"query":{"offset":"7","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"displayLayout":{"type":"list","columns":3},"align":"wide","layout":{"inherit":true}} -->
-					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
-					<!-- wp:spacer {"height":160} -->
-					<div style="height:160px" aria-hidden="true" class="wp-block-spacer"></div>
-					<!-- /wp:spacer -->
-
-					<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
-
-					<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
-
-					<!-- wp:post-excerpt /-->
-
-					<!-- wp:post-date {"format":"F j, Y","isLink":true,"fontSize":"small"} /-->
-					<!-- /wp:post-template --></div>
-					<!-- /wp:query --></div>
-					<!-- /wp:column -->
-
-					<!-- wp:column -->
-					<div class="wp-block-column"><!-- wp:query {"query":{"offset":"8","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"displayLayout":{"type":"list","columns":3},"align":"wide","layout":{"inherit":true}} -->
-					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
-					<!-- wp:spacer {"height":96} -->
-					<div style="height:96px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
 					<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->

--- a/inc/patterns/query-large-titles.php
+++ b/inc/patterns/query-large-titles.php
@@ -6,7 +6,7 @@ return array(
 	'title'      => __( 'Large post titles', 'twentytwentytwo' ),
 	'categories' => array( 'query' ),
 	'blockTypes' => array( 'core/query' ),
-	'content'    => '<!-- wp:query {"query":{"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"perPage":8},"align":"wide"} -->
+	'content'    => '<!-- wp:query {"query":{"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"perPage":3},"align":"wide"} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template -->
 					<!-- wp:columns -->
 					<div class="wp-block-columns"><!-- wp:column {"verticalAlignment":"top","width":"4em"} -->

--- a/inc/patterns/query-simple-blog.php
+++ b/inc/patterns/query-simple-blog.php
@@ -6,7 +6,7 @@ return array(
 	'title'      => __( 'Simple blog posts', 'twentytwentytwo' ),
 	'categories' => array( 'query' ),
 	'blockTypes' => array( 'core/query' ),
-	'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"inherit":true}} -->
+	'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"layout":{"inherit":true}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->
 					<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}},"typography":{"fontStyle":"normal","fontWeight":"300"},"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary","fontSize":"huge"} /-->
 

--- a/inc/patterns/query-simple-blog.php
+++ b/inc/patterns/query-simple-blog.php
@@ -6,7 +6,7 @@ return array(
 	'title'      => __( 'Simple blog posts', 'twentytwentytwo' ),
 	'categories' => array( 'query' ),
 	'blockTypes' => array( 'core/query' ),
-	'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"perPage":10},"layout":{"inherit":true}} -->
+	'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"inherit":true}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->
 					<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}},"typography":{"fontStyle":"normal","fontWeight":"300"},"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary","fontSize":"huge"} /-->
 

--- a/inc/patterns/query-text-grid.php
+++ b/inc/patterns/query-text-grid.php
@@ -6,7 +6,7 @@ return array(
 	'title'      => __( 'Text-based grid of posts', 'twentytwentytwo' ),
 	'categories' => array( 'query' ),
 	'blockTypes' => array( 'core/query' ),
-	'content'    => '<!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":12},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
+	'content'    => '<!-- wp:query {"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":3},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
 
 					<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/issues/37072

Patterns are really hard to handle in terms of performance as they can contain many many blocks and we not only have to parse and render them, but also do some recursive checks about the allowed blocks settings.

While this is an issue we have to handle in general and in core, for now I think we need to 'lighten' the theme's `Query Loop` patterns regarding the number of posts it previews. The point of a pattern is to showcase some design and with some pre-selected blocks(the inner Post blocks, etc..). It's already opinionated about the number of posts, so we could just show the minimum number required to make the pattern show its point.

With the increasing number of patterns it's crucial to think of these performance problems when we create one - again this is something that core needs to find a way to handle better.

The problem is absolutely noticeable with this theme as the number of posts was really big, taking not only a really long time to preview them, but also (maybe)failing to preview them at all - I didn't wait too much time to see if they would eventually render. If you try to see `Query` patterns without this PR you can see it.

## Notes
I removed some extra props that were not needed like `displayLayout` when `list` was used.
I think we should do this for GB and core `Query` patterns as well.