### PR TITLE
Add static analysis to GitHub Actions workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -64,3 +64,32 @@ jobs:
         run: composer install --no-progress
       - name: Check coding standards using PHPCS
         run: composer standards:check -- --runtime-set ignore_warnings_on_exit true --runtime-set testVersion 5.8-
+
+  phpstan_analysis:
+    name: PHPStan static analysis
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout repository
+      - name: Checkout
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+      # Setup PHP versions, run checks
+      - name: PHP setup
+        uses: shivammathur/setup-php@a7f90656b3be3996d1ec5501e8e25d5d35aa9bb2 # v2.15.0
+        with:
+          php-version: 7.4
+      - name: Get composer cache directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Cache composer dependencies
+        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      - name: Install composer packages
+        run: composer install --no-progress
+      - name: Run static analysis using PHPStan
+        run: composer analyze

--- a/functions.php
+++ b/functions.php
@@ -43,13 +43,15 @@ if ( ! function_exists( 'twentytwentytwo_styles' ) ) :
 	 * @return void
 	 */
 	function twentytwentytwo_styles() {
-
 		// Register theme stylesheet.
+		$theme_version = wp_get_theme()->get( 'Version' );
+
+		$version_string = is_string( $theme_version ) ? $theme_version : false;
 		wp_register_style(
 			'twentytwentytwo-style',
 			get_template_directory_uri() . '/style.css',
 			array(),
-			wp_get_theme()->get( 'Version' )
+			$version_string
 		);
 
 		// Add styles inline.

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -9,14 +9,16 @@
  * Registers block patterns and categories.
  *
  * @since Twenty Twenty-Two 1.0
+ *
+ * @return void
  */
 function twentytwentytwo_register_block_patterns() {
 	$block_pattern_categories = array(
 		'featured' => array( 'label' => __( 'Featured', 'twentytwentytwo' ) ),
-		'footer' => array( 'label' => __( 'Footers', 'twentytwentytwo' ) ),
-		'header' => array( 'label' => __( 'Headers', 'twentytwentytwo' ) ),
-		'query'   => array( 'label' => __( 'Query', 'twentytwentytwo' ) ),
-		'pages'   => array( 'label' => __( 'Pages', 'twentytwentytwo' ) ),
+		'footer'   => array( 'label' => __( 'Footers', 'twentytwentytwo' ) ),
+		'header'   => array( 'label' => __( 'Headers', 'twentytwentytwo' ) ),
+		'query'    => array( 'label' => __( 'Query', 'twentytwentytwo' ) ),
+		'pages'    => array( 'label' => __( 'Pages', 'twentytwentytwo' ) ),
 	);
 
 	/**
@@ -117,7 +119,7 @@ function twentytwentytwo_register_block_patterns() {
 	 *
 	 * @since Twenty Twenty-Two 1.0
 	 *
-	 * @param $block_patterns array List of block patterns by name.
+	 * @param array $block_patterns List of block patterns by name.
 	 */
 	$block_patterns = apply_filters( 'twentytwentytwo_block_patterns', $block_patterns );
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,4 +6,5 @@ includes:
 parameters:
 	level: max
 	paths:
+		- functions.php
 		- inc/

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,3 +5,5 @@ includes:
 	- vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: max
+	paths:
+		- inc/


### PR DESCRIPTION
**Description**

The static analyzer PHPStan was already being pulled into the project as a Composer dependency, but it was not being used.

This PR configures PHPStan to work correctly and fixes the few issues it found.

**Screenshots**

Static analysis running locally with detected issues:
![_ 2021-12-16 at 9 06 00 AM entytwentytwo](https://user-images.githubusercontent.com/83631/146386685-3e8041aa-3149-4371-b9f1-2c76ac9fe852.jpeg)

Static analysis running within GitHub Actions:
![Fix static analysis issues · WordPress_twentytwentytwo@3d66ce7 - Google Chr  2021-12-16 at 9 05 11 AM](https://user-images.githubusercontent.com/83631/146386563-06272bbe-e2ba-48a1-96b0-10b4d1762904.jpeg)

**Testing Instructions** 

1. Run `composer analyze` to manually trigger the PHPStan analysis.
