### PR TITLE
Port back-compat code from twentytwentyone

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -9,6 +9,10 @@
  * @since Twenty Twenty-Two 1.0
  */
 
+// This theme requires WordPress 5.8 or later.
+if ( version_compare( $GLOBALS['wp_version'], '5.8', '<' ) ) {
+	require get_template_directory() . '/inc/back-compat.php';
+}
 
 if ( ! function_exists( 'twentytwentytwo_support' ) ) :
 

--- a/inc/back-compat.php
+++ b/inc/back-compat.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Twenty Twenty-Two: Backwards compatibility functionality
+ *
+ * Prevents the theme from running on WordPress versions prior to 5.8,
+ * since this theme is not meant to be backward compatible beyond that and
+ * relies on many newer functions and markup changes introduced in 5.8.
+ *
+ * @since Twenty Twenty-Two 1.0
+ */
+
+/**
+ * Display upgrade notice on theme switch.
+ *
+ * @since Twenty Twenty-Two 1.0
+ *
+ * @return void
+ */
+function twentytwentytwo_switch_theme() {
+	add_action( 'admin_notices', 'twentytwentytwo_upgrade_notice' );
+}
+add_action( 'after_switch_theme', 'twentytwentytwo_switch_theme' );
+
+/**
+ * Adds a message for unsuccessful theme switch.
+ *
+ * Prints an update nag after an unsuccessful attempt to switch to
+ * the theme on WordPress versions prior to 5.8.
+ *
+ * @since Twenty Twenty-Two 1.0
+ *
+ * @global string $wp_version WordPress version.
+ *
+ * @return void
+ */
+function twentytwentytwo_upgrade_notice() {
+	echo '<div class="error"><p>';
+	printf(
+	/* translators: %s: WordPress Version. */
+		esc_html__( 'This theme requires WordPress 5.8 or newer. You are running version %s. Please upgrade.', 'twentytwentyone' ),
+		esc_html( $GLOBALS['wp_version'] )
+	);
+	echo '</p></div>';
+}
+
+/**
+ * Prevents the Customizer from being loaded on WordPress versions prior to 5.8.
+ *
+ * @since Twenty Twenty-Two 1.0
+ *
+ * @global string $wp_version WordPress version.
+ *
+ * @return void
+ */
+function twentytwentytwo_customize() {
+	wp_die(
+		sprintf(
+		/* translators: %s: WordPress Version. */
+			esc_html__( 'This theme requires WordPress 5.8 or newer. You are running version %s. Please upgrade.', 'twentytwentyone' ),
+			esc_html( $GLOBALS['wp_version'] )
+		),
+		'',
+		array(
+			'back_link' => true,
+		)
+	);
+}
+add_action( 'load-customize.php', 'twentytwentytwo_customize' );
+
+/**
+ * Prevents the Theme Preview from being loaded on WordPress versions prior to 5.8.
+ *
+ * @since Twenty Twenty-Two 1.0
+ *
+ * @global string $wp_version WordPress version.
+ *
+ * @return void
+ */
+function twentytwentytwo_preview() {
+	if ( isset( $_GET['preview'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		wp_die(
+			sprintf(
+			/* translators: %s: WordPress Version. */
+				esc_html__( 'This theme requires WordPress 5.8 or newer. You are running version %s. Please upgrade.', 'twentytwentyone' ),
+				esc_html( $GLOBALS['wp_version'] )
+			)
+		);
+	}
+}
+add_action( 'template_redirect', 'twentytwentytwo_preview' );

--- a/inc/back-compat.php
+++ b/inc/back-compat.php
@@ -37,7 +37,7 @@ function twentytwentytwo_upgrade_notice() {
 	echo '<div class="error"><p>';
 	printf(
 	/* translators: %s: WordPress Version. */
-		esc_html__( 'This theme requires WordPress 5.8 or newer. You are running version %s. Please upgrade.', 'twentytwentyone' ),
+		esc_html__( 'This theme requires WordPress 5.8 or newer. You are running version %s. Please upgrade.', 'twentytwentytwo' ),
 		esc_html( $GLOBALS['wp_version'] )
 	);
 	echo '</p></div>';
@@ -56,7 +56,7 @@ function twentytwentytwo_customize() {
 	wp_die(
 		sprintf(
 		/* translators: %s: WordPress Version. */
-			esc_html__( 'This theme requires WordPress 5.8 or newer. You are running version %s. Please upgrade.', 'twentytwentyone' ),
+			esc_html__( 'This theme requires WordPress 5.8 or newer. You are running version %s. Please upgrade.', 'twentytwentytwo' ),
 			esc_html( $GLOBALS['wp_version'] )
 		),
 		'',
@@ -81,7 +81,7 @@ function twentytwentytwo_preview() {
 		wp_die(
 			sprintf(
 			/* translators: %s: WordPress Version. */
-				esc_html__( 'This theme requires WordPress 5.8 or newer. You are running version %s. Please upgrade.', 'twentytwentyone' ),
+				esc_html__( 'This theme requires WordPress 5.8 or newer. You are running version %s. Please upgrade.', 'twentytwentytwo' ),
 				esc_html( $GLOBALS['wp_version'] )
 			)
 		);


### PR DESCRIPTION
As a follow-up to the discussion during the core dev chat on Dec.15, this PR ports over the backwards-compatibility code from `twentytwentyone`. This adds admin notices and tries to avoid loading the theme on incompatible WordPress versions.
