### PR TITLE
Fix: Quote block border issue with right align settings

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -249,7 +249,7 @@
 			},
 			"core/quote": {
 				"border": {
-					"width": "0 0 0 1px"
+					"width": "1px"
 				}
 			},
 			"core/site-title": {


### PR DESCRIPTION
**Description**

Currently, the border size of the quote block has been set only for the left side, so when someone changes the alignment to the right, it doesn't show the border on the right side. Instead of using `0 0 0 1px`, we can use `1px` only; Gutenberg will take care of showing border based on alignment setting.
 
**Screenshots**


https://user-images.githubusercontent.com/17360543/147378570-49c95717-6a84-4e27-b212-c05f778f925b.mov



**Testing Instructions** 

1. Insert Quote block
2. Change alignment

Fixes: #278
