### PR TITLE
Use custom unit spacers in templates and patterns

### DIFF
--- a/inc/patterns/header-large-dark.php
+++ b/inc/patterns/header-large-dark.php
@@ -7,8 +7,8 @@ return array(
 	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-					<div class="wp-block-group alignfull"><!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"var(--wp--custom--spacing--large, 8rem)"},"margin":{"bottom":"var(--wp--custom--spacing--large, 8rem)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
-					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="margin-bottom:var(--wp--custom--spacing--large, 8rem);padding-top:0px;padding-bottom:var(--wp--custom--spacing--large, 8rem);"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0px","bottom":"0px"}}},"layout":{"inherit":true}} -->
+					<div class="wp-block-group alignfull"><!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"var(--wp--custom--spacing--large, 8rem)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-bottom:var(--wp--custom--spacing--large, 8rem);"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0px","bottom":"0px"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-top:0px;padding-bottom:0px;"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var(--wp--custom--spacing--small, 1.25rem)","bottom":"var(--wp--custom--spacing--large, 8rem)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:var(--wp--custom--spacing--small, 1.25rem);padding-bottom:var(--wp--custom--spacing--large, 8rem)"><!-- wp:group {"layout":{"type":"flex"}} -->
 					<div class="wp-block-group"><!-- wp:site-logo {"width":64} /-->
@@ -29,6 +29,10 @@ return array(
 					<!-- wp:image {"align":"full","sizeSlug":"full","linkDestination":"none"} -->
 					<figure class="wp-block-image alignfull size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/flight-path-on-transparent-c.png" alt="' . esc_attr__( 'Illustration of a bird flying.', 'twentytwentytwo' ) . '"/></figure>
 					<!-- /wp:image --></div>
-					<!-- /wp:group --></div>
+					<!-- /wp:group -->
+
+					<!-- wp:spacer {"height":"calc(var(--wp--custom--spacing--large, 8rem) - var( --wp--style--block-gap ))"} -->
+					<div style="height:calc(var(--wp--custom--spacing--large, 8rem) - var( --wp--style--block-gap ))" aria-hidden="true" class="wp-block-spacer"></div>
+					<!-- /wp:spacer --></div>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-small-dark.php
+++ b/inc/patterns/header-small-dark.php
@@ -7,8 +7,8 @@ return array(
 	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-					<div class="wp-block-group alignfull"><!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"0px"},"margin":{"bottom":"var(--wp--custom--spacing--large, 8rem)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
-					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="margin-bottom:var(--wp--custom--spacing--large, 8rem);padding-top:0px;padding-bottom:0px;"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0px","bottom":"0px"}}},"layout":{"inherit":true}} -->
+					<div class="wp-block-group alignfull"><!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-bottom:0px;"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0px","bottom":"0px"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-top:0px;padding-bottom:0px;"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var(--wp--custom--spacing--small, 1.25rem)","bottom":"var(--wp--custom--spacing--large, 8rem)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:var(--wp--custom--spacing--small, 1.25rem);padding-bottom:var(--wp--custom--spacing--large, 8rem)"><!-- wp:group {"layout":{"type":"flex"}} -->
 					<div class="wp-block-group"><!-- wp:site-logo {"width":64} /-->
@@ -25,6 +25,10 @@ return array(
 					<!-- wp:image {"align":"wide","sizeSlug":"full","linkDestination":"none"} -->
 					<figure class="wp-block-image alignwide size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/flight-path-on-transparent-d.png" alt="' . esc_attr__( 'Illustration of a bird flying.', 'twentytwentytwo' ) . '"/></figure>
 					<!-- /wp:image --></div>
-					<!-- /wp:group --></div>
+					<!-- /wp:group -->
+
+					<!-- wp:spacer {"height":"calc(var(--wp--custom--spacing--large, 8rem) - var( --wp--style--block-gap ))"} -->
+					<div style="height:calc(var(--wp--custom--spacing--large, 8rem) - var( --wp--style--block-gap ))" aria-hidden="true" class="wp-block-spacer"></div>
+					<!-- /wp:spacer --></div>
 					<!-- /wp:group -->',
 );

--- a/parts/header-large-dark.html
+++ b/parts/header-large-dark.html
@@ -1,7 +1,11 @@
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"0px"},"margin":{"bottom":"var(--wp--custom--spacing--large, 8rem)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="margin-bottom:var(--wp--custom--spacing--large, 8rem);padding-top:0px;padding-bottom:0px"><!-- wp:template-part {"slug":"header","tagName":"header","align":"wide"} /-->
+<div class="wp-block-group"><!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-bottom:0px"><!-- wp:template-part {"slug":"header","tagName":"header","align":"wide"} /-->
 
 <!-- wp:pattern {"slug":"twentytwentytwo/hidden-heading-and-bird"} /--></div>
-<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:spacer {"height":"calc(var(--wp--custom--spacing--large, 8rem) - var( --wp--style--block-gap ))"} -->
+<div style="height:calc(var(--wp--custom--spacing--large, 8rem) - var( --wp--style--block-gap ))" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></div>
 <!-- /wp:group -->

--- a/parts/header-small-dark.html
+++ b/parts/header-small-dark.html
@@ -1,7 +1,11 @@
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"0px"},"margin":{"bottom":"var(--wp--custom--spacing--large, 8rem)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="margin-bottom:var(--wp--custom--spacing--large, 8rem);padding-top:0px;padding-bottom:0px"><!-- wp:template-part {"slug":"header","tagName":"header","align":"wide"} /-->
+<div class="wp-block-group"><!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-bottom:0px"><!-- wp:template-part {"slug":"header","tagName":"header","align":"wide"} /-->
 
 <!-- wp:pattern {"slug":"twentytwentytwo/hidden-bird"} /--></div>
-<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:spacer {"height":"calc(var(--wp--custom--spacing--large, 8rem) - var( --wp--style--block-gap ))"} -->
+<div style="height:calc(var(--wp--custom--spacing--large, 8rem) - var( --wp--style--block-gap ))" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></div>
 <!-- /wp:group -->

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -21,8 +21,8 @@
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 
-<!-- wp:spacer {"height":112} -->
-<div style="height:112px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":"calc(var(--wp--custom--spacing--large, 8rem) - var( --wp--style--block-gap ))"} -->
+<div style="height:calc(var(--wp--custom--spacing--large, 8rem) - var( --wp--style--block-gap ))" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 <!-- /wp:post-template -->
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -19,8 +19,8 @@
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 
-<!-- wp:spacer {"height":112} -->
-<div style="height:112px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":"calc(var(--wp--custom--spacing--large, 8rem) - var( --wp--style--block-gap ))"} -->
+<div style="height:calc(var(--wp--custom--spacing--large, 8rem) - var( --wp--style--block-gap ))" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer --></div>
 <!-- /wp:group -->
 <!-- /wp:post-template -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,8 +19,8 @@
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 
-<!-- wp:spacer {"height":112} -->
-<div style="height:112px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":"calc(var(--wp--custom--spacing--large, 8rem) - var( --wp--style--block-gap ))"} -->
+<div style="height:calc(var(--wp--custom--spacing--large, 8rem) - var( --wp--style--block-gap ))" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer --></div>
 <!-- /wp:group -->
 <!-- /wp:post-template -->

--- a/templates/search.html
+++ b/templates/search.html
@@ -23,8 +23,8 @@
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 
-<!-- wp:spacer {"height":112} -->
-<div style="height:112px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- wp:spacer {"height":"calc(var(--wp--custom--spacing--large, 8rem) - var( --wp--style--block-gap ))"} -->
+<div style="height:calc(var(--wp--custom--spacing--large, 8rem) - var( --wp--style--block-gap ))" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer --></div>
 <!-- /wp:group -->
 <!-- /wp:post-template -->


### PR DESCRIPTION
Fixes #272. 

⚠️ This PR is reliant on https://github.com/WordPress/gutenberg/pull/36186 being backported for the 5.9 release. 

When this PR is active, everything should look the same on the front-end and in the editor. Here's what's changed under the hood: 

- The space between posts is now uses custom units, and maps directly to the theme's `var(--wp--custom--spacing--large)` variable. Before, it was a static pixel number that approximated that value.
- The dark header templates and patterns now include spacers to adjust their bottom margin, instead of hardcoding a margin value. That means folks can edit that value via the UI now. 

## Screenshot
 
<img width="1280" alt="Screen Shot 2022-01-04 at 8 34 40 AM" src="https://user-images.githubusercontent.com/1202812/148067806-1beffbfb-f1c1-4a95-8fd8-cfb753c11834.png">

