### PR TITLE
Change Site Title in the footer to a paragraph instead of an H1

### DIFF
--- a/inc/patterns/footer-default.php
+++ b/inc/patterns/footer-default.php
@@ -8,7 +8,7 @@ return array(
 	'blockTypes' => array( 'core/template-part/footer' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title /-->
+					<div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem"><!-- wp:site-title {"level":0} /-->
 
 					<!-- wp:paragraph {"align":"right"} -->
 					<p class="has-text-align-right">' .


### PR DESCRIPTION
The change from #40 appears to have been lost at some point. This PR re-instates it. To test, confirm that the Site Title in the footer appears in a `p` tag instead of an `h1`.

<img width="617" alt="Screen Shot 2022-01-05 at 12 12 40 PM" src="https://user-images.githubusercontent.com/1202812/148259657-59a33524-ff8c-4d79-bf66-9d5a70c403ed.png">


Closes #321 