### PR TITLE
Update required WordPress version to 5.9.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To get started with development:
 ## Requirements
 
 - Gutenberg plugin (latest)
-- WordPress 5.8+
+- WordPress 5.9+
 - PHP 5.6+
 - License: [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html) or later
 

--- a/readme.txt
+++ b/readme.txt
@@ -18,9 +18,7 @@ Whether you’re building a single-page website, a blog, a business website, or 
 == Changelog ==
 
 = 1.0 =
-* Released: December
-
-https://wordpress.org/support/article/twenty-twenty-two-changelog#Version_1.0
+* Released: January 25, 2022
 
 == Copyright ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Twenty Twenty-Two ===
 Contributors: wordpressdotorg
-Requires at least: 5.8
+Requires at least: 5.9
 Tested up to: 5.9
 Requires PHP: 5.6
 Stable tag: 1.0

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/wordpress/twentytwentytwo/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Built on a solidly designed foundation, Twenty Twenty-Two embraces the idea that everyone deserves a truly unique website. The theme’s subtle styles are inspired by the diversity and versatility of birds: its typography is lightweight yet strong, its color palette is drawn from nature, and its layout elements sit gently on the page. The true richness of Twenty Twenty-Two lies in its opportunity for customization. The theme is built to take advantage of the Full Site Editing features introduced in WordPress 5.9, which means that colors, typography, and the layout of every single page on your site can be customized to suit your vision. It also includes dozens of block patterns, opening the door to a wide range of professionally designed layouts in just a few clicks. Whether you’re building a single-page website, a blog, a business website, or a portfolio, Twenty Twenty-Two will help you create a site that is uniquely yours.
-Requires at least: 5.8
+Requires at least: 5.9
 Tested up to: 5.9
 Requires PHP: 5.6
 Version: 1.0


### PR DESCRIPTION
As per [the notes here](https://github.com/WordPress/twentytwentytwo/pull/306#discussion_r770605126), this PR updates the required WP version to 5.9 for the theme. 

I tested this alongside the current version of WordPress `trunk` (which is already marked as 5.9). It works fine and shows no errors. 

If you already have the the theme active on an earlier version of WordPress, it will continue to work with the Gutenberg plugin active, but you'll see this message: 

<img width="371" alt="Screen Shot 2022-01-10 at 9 40 40 AM" src="https://user-images.githubusercontent.com/1202812/148784219-ce2d3307-1654-46c7-8092-28ab35768565.png">

If you deactivate the theme, you will not be able to re-activate it without upgrading to 5.9: 

<img width="372" alt="Screen Shot 2022-01-10 at 9 41 54 AM" src="https://user-images.githubusercontent.com/1202812/148784379-1ddf44e6-1584-4365-8e33-dd41d162e2dd.png">

