### PR TITLE
Try a static spacer underneath the header

### DIFF
--- a/inc/patterns/header-large-dark.php
+++ b/inc/patterns/header-large-dark.php
@@ -7,8 +7,8 @@ return array(
 	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-					<div class="wp-block-group alignfull"><!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"var(--wp--custom--spacing--large, 8rem)"},"margin":{"bottom":"var(--wp--custom--spacing--large, 8rem)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
-					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="margin-bottom:var(--wp--custom--spacing--large, 8rem);padding-top:0px;padding-bottom:var(--wp--custom--spacing--large, 8rem);"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0px","bottom":"0px"}}},"layout":{"inherit":true}} -->
+					<div class="wp-block-group alignfull"><!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"var(--wp--custom--spacing--large, 8rem)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-bottom:var(--wp--custom--spacing--large, 8rem);"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0px","bottom":"0px"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-top:0px;padding-bottom:0px;"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var(--wp--custom--spacing--small, 1.25rem)","bottom":"var(--wp--custom--spacing--large, 8rem)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:var(--wp--custom--spacing--small, 1.25rem);padding-bottom:var(--wp--custom--spacing--large, 8rem)"><!-- wp:group {"layout":{"type":"flex"}} -->
 					<div class="wp-block-group"><!-- wp:site-logo {"width":64} /-->
@@ -29,6 +29,8 @@ return array(
 					<!-- wp:image {"align":"full","sizeSlug":"full","linkDestination":"none"} -->
 					<figure class="wp-block-image alignfull size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/flight-path-on-transparent-c.png" alt="' . esc_attr__( 'Illustration of a bird flying.', 'twentytwentytwo' ) . '"/></figure>
 					<!-- /wp:image --></div>
-					<!-- /wp:group --></div>
+					<!-- /wp:group --><!-- wp:spacer {"height":66} -->
+					<div style="height:66px" aria-hidden="true" class="wp-block-spacer"></div>
+					<!-- /wp:spacer --></div>
 					<!-- /wp:group -->',
 );

--- a/inc/patterns/header-small-dark.php
+++ b/inc/patterns/header-small-dark.php
@@ -7,8 +7,8 @@ return array(
 	'categories' => array( 'header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-					<div class="wp-block-group alignfull"><!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"0px"},"margin":{"bottom":"var(--wp--custom--spacing--large, 8rem)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
-					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="margin-bottom:var(--wp--custom--spacing--large, 8rem);padding-top:0px;padding-bottom:0px;"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0px","bottom":"0px"}}},"layout":{"inherit":true}} -->
+					<div class="wp-block-group alignfull"><!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+					<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-bottom:0px;"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0px","bottom":"0px"}}},"layout":{"inherit":true}} -->
 					<div class="wp-block-group alignfull" style="padding-top:0px;padding-bottom:0px;"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var(--wp--custom--spacing--small, 1.25rem)","bottom":"var(--wp--custom--spacing--large, 8rem)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 					<div class="wp-block-group alignwide" style="padding-top:var(--wp--custom--spacing--small, 1.25rem);padding-bottom:var(--wp--custom--spacing--large, 8rem)"><!-- wp:group {"layout":{"type":"flex"}} -->
 					<div class="wp-block-group"><!-- wp:site-logo {"width":64} /-->
@@ -25,6 +25,9 @@ return array(
 					<!-- wp:image {"align":"wide","sizeSlug":"full","linkDestination":"none"} -->
 					<figure class="wp-block-image alignwide size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/flight-path-on-transparent-d.png" alt="' . esc_attr__( 'Illustration of a bird flying.', 'twentytwentytwo' ) . '"/></figure>
 					<!-- /wp:image --></div>
-					<!-- /wp:group --></div>
+					<!-- /wp:group -->
+					<!-- wp:spacer {"height":66} -->
+					<div style="height:66px" aria-hidden="true" class="wp-block-spacer"></div>
+					<!-- /wp:spacer --></div>
 					<!-- /wp:group -->',
 );

--- a/parts/header-large-dark.html
+++ b/parts/header-large-dark.html
@@ -1,6 +1,6 @@
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-bottom:0px"><!-- wp:template-part {"slug":"header","tagName":"header","align":"wide"} /-->
+<div class="wp-block-group"><!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"var(--wp--custom--spacing--large, 8rem)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-bottom:var(--wp--custom--spacing--large, 8rem)"><!-- wp:template-part {"slug":"header","tagName":"header","align":"wide"} /-->
 
 <!-- wp:pattern {"slug":"twentytwentytwo/hidden-heading-and-bird"} /--></div>
 <!-- /wp:group --><!-- wp:spacer {"height":66} -->

--- a/parts/header-large-dark.html
+++ b/parts/header-large-dark.html
@@ -1,7 +1,9 @@
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"0px"},"margin":{"bottom":"var(--wp--custom--spacing--large, 8rem)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="margin-bottom:var(--wp--custom--spacing--large, 8rem);padding-top:0px;padding-bottom:0px"><!-- wp:template-part {"slug":"header","tagName":"header","align":"wide"} /-->
+<div class="wp-block-group"><!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-bottom:0px"><!-- wp:template-part {"slug":"header","tagName":"header","align":"wide"} /-->
 
 <!-- wp:pattern {"slug":"twentytwentytwo/hidden-heading-and-bird"} /--></div>
-<!-- /wp:group --></div>
+<!-- /wp:group --><!-- wp:spacer {"height":66} -->
+<div style="height:66px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></div>
 <!-- /wp:group -->

--- a/parts/header-small-dark.html
+++ b/parts/header-small-dark.html
@@ -1,7 +1,9 @@
 <!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group"><!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"0px"},"margin":{"bottom":"var(--wp--custom--spacing--large, 8rem)"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="margin-bottom:var(--wp--custom--spacing--large, 8rem);padding-top:0px;padding-bottom:0px"><!-- wp:template-part {"slug":"header","tagName":"header","align":"wide"} /-->
+<div class="wp-block-group"><!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"0px","bottom":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-bottom:0px"><!-- wp:template-part {"slug":"header","tagName":"header","align":"wide"} /-->
 
 <!-- wp:pattern {"slug":"twentytwentytwo/hidden-bird"} /--></div>
-<!-- /wp:group --></div>
+<!-- /wp:group --><!-- wp:spacer {"height":66} -->
+<div style="height:66px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></div>
 <!-- /wp:group -->


### PR DESCRIPTION
Alternative to #325 and #319. 
Closes #272.

This PR adds a static spacer block under the header to replace the unsupported margin value that was there previously. Ideally, this should be a dynamic value, but this is the best we can do for the moment since that's not landing in 5.9. 

Using a static value produces more space than intended on mobile, but overall I think the usability enhancement makes it worthwhile for the initial release. This also makes for a more efficient transition to #325, once dynamic spacer units will be supported in a future minor release. I (somewhat regretfully) think this is the best path forward for the moment. 

---

**Editor:** 

<img width="1331" alt="Screen Shot 2022-01-10 at 11 36 08 AM" src="https://user-images.githubusercontent.com/1202812/148802831-a27d43ea-0eb5-4f39-8ec6-bff190fa5161.png">

**Frontend:** 

(Front-end desktop views are identical to `trunk`.)

Before|After
---|---
<img width="374" alt="Screen Shot 2022-01-10 at 11 33 34 AM" src="https://user-images.githubusercontent.com/1202812/148802577-1b4ee2f1-5efe-466f-a66a-3673d45a713a.png">|<img width="373" alt="Screen Shot 2022-01-10 at 11 33 45 AM" src="https://user-images.githubusercontent.com/1202812/148802584-d3c0296b-7d58-4891-bd9f-cd56980e22a8.png">

Before|After
---|---
<img width="374" alt="Screen Shot 2022-01-10 at 11 33 20 AM" src="https://user-images.githubusercontent.com/1202812/148802720-1f7cfb1e-b637-466a-84be-3ee066c97534.png">|<img width="374" alt="Screen Shot 2022-01-10 at 11 29 13 AM" src="https://user-images.githubusercontent.com/1202812/148802629-5dcb2834-9099-47be-9ae0-e80a6b7d8ab9.png">

