### PR TITLE
Update copyright year to match core.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -24,7 +24,7 @@ https://wordpress.org/support/article/twenty-twenty-two-changelog#Version_1.0
 
 == Copyright ==
 
-Twenty Twenty-Two WordPress Theme, 2021 WordPress.org
+Twenty Twenty-Two WordPress Theme, 2021-2022 WordPress.org
 Twenty Twenty-Two is distributed under the terms of the GNU GPL.
 
 This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
**Description**

In https://core.trac.wordpress.org/changeset/52427, the copyright year for the theme was changed in Core. This PR syncs that change back to the development repo.