### PR TITLE
Try body instead of wp-site-blocks

### DIFF
--- a/style.css
+++ b/style.css
@@ -95,8 +95,7 @@ a:active {
  * https://github.com/WordPress/gutenberg/issues/35884
  */
 
-.wp-site-blocks,
-body > .is-root-container,
+body,
 .edit-post-visual-editor__post-title-wrapper,
 .wp-block-group.alignfull,
 .wp-block-cover.alignfull,

--- a/style.css
+++ b/style.css
@@ -95,8 +95,13 @@ a:active {
  * https://github.com/WordPress/gutenberg/issues/35884
  */
 
-body,
-.edit-post-visual-editor__post-title-wrapper,
+
+body {
+	padding-left: var(--wp--custom--spacing--outer) !important;
+	padding-right: var(--wp--custom--spacing--outer) !important;
+}
+
+ .edit-post-visual-editor__post-title-wrapper,
 .wp-block-group.alignfull,
 .wp-block-cover.alignfull,
 .is-root-container .wp-block[data-align="full"] > .wp-block-group,


### PR DESCRIPTION
**Description**

Closes #330 (potentially). As pointed out in #330, there's inappropriate padding left/right being added to patterns within the block previews. This PR switches the selector `--wp--custom--spacing--outer` is applied to, from `.wp-site-blocks` and `body > .is-root-container` to just `body`. 

The end result is the left/right padding is properly applied within the editor, but not doubled-up within the BlockPreview component. I did have to use `!important` though, as the BlockPreview component has an inline style of `padding: 0` on it. 

**Screenshots**

_Add screenshots of the change, if applicable_ 

**Testing Instructions** 

_Provide steps for testing_

1. Look at patterns in the Pattern Library, see if align `full` patterns are indeed
2. Add an align `full` pattern to the page, see that its still fullwidth
3. Check the pattern on the front-end, see if its still fullwidth
3. Check other elements to ensure switching padding to `body` does not negatively affect other areas of the theme
