### PR TITLE
Try alternate theme.json files

### DIFF
--- a/styles/blue.json
+++ b/styles/blue.json
@@ -1,0 +1,81 @@
+{
+	"version": 2,
+	"settings": {
+		"color": {
+			"palette": [
+				{
+					"slug": "foreground",
+					"color": "#3F67C6",
+					"name": "Foreground"
+				},
+				{
+					"slug": "background",
+					"color": "#FCF5ED",
+					"name": "Background"
+				},
+				{
+					"slug": "primary",
+					"color": "#385BAD",
+					"name": "Primary"
+				},
+				{
+					"slug": "secondary",
+					"color": "#F7EBDD",
+					"name": "Secondary"
+				},
+				{
+					"slug": "tertiary",
+					"color": "#ffffff",
+					"name": "Tertiary"
+				}
+			]
+		},
+		"layout": {
+			"wideSize": "1060px"
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/post-title": {
+				"typography": {
+					"fontWeight": "700"
+				}
+			}
+		},
+		"elements": {
+			"h1": {
+				"typography": {
+					"fontWeight": "700"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontWeight": "700"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontWeight": "700"
+				}
+			},
+			"h4": {
+				"typography": {
+					"fontWeight": "700"
+				}
+			},
+			"h5": {
+				"typography": {
+					"fontWeight": "700"
+				}
+			},
+			"h6": {
+				"typography": {
+					"fontWeight": "700"
+				}
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--system-font)"
+		}
+	}
+}

--- a/styles/blue.json
+++ b/styles/blue.json
@@ -42,6 +42,10 @@
 				}
 			}
 		},
+		"color": {
+			"background": "var(--wp--preset--color--background)",
+			"text": "var(--wp--preset--color--foreground)"
+		},
 		"elements": {
 			"h1": {
 				"typography": {

--- a/styles/mint.json
+++ b/styles/mint.json
@@ -1,0 +1,66 @@
+{
+	"version": 2,
+	"settings": {
+		"color": {
+			"duotone": [
+				{
+					"colors": [
+						"#000000",
+						"#FFFFFF"
+					],
+					"slug": "default-filter",
+					"name": "Default filter"
+				}
+			],
+			"palette": [
+				{
+					"slug": "foreground",
+					"color": "#000000",
+					"name": "Foreground"
+				},
+				{
+					"slug": "background",
+					"color": "#FFFFFF",
+					"name": "Background"
+				},
+				{
+					"slug": "primary",
+					"color": "#000000",
+					"name": "Primary"
+				},
+				{
+					"slug": "secondary",
+					"color": "#93FFDE",
+					"name": "Secondary"
+				},
+				{
+					"slug": "tertiary",
+					"color": "#93FFDE",
+					"name": "Tertiary"
+				}
+			]
+		},
+		"layout": {
+			"wideSize": "1060px"
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/image": {
+				"filter": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
+				}
+			},
+			"core/post-featured-image": {
+				"filter": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
+				}
+			},
+			"core/site-logo": {
+				"filter": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
+				}
+			}
+		}
+	}
+}

--- a/styles/mint.json
+++ b/styles/mint.json
@@ -61,6 +61,10 @@
 					"duotone": "var(--wp--preset--duotone--default-filter)"
 				}
 			}
+		},
+		"color": {
+			"background": "var(--wp--preset--color--background)",
+			"text": "var(--wp--preset--color--foreground)"
 		}
 	}
 }

--- a/styles/pink.json
+++ b/styles/pink.json
@@ -72,6 +72,10 @@
 				}
 			}
 		},
+		"color": {
+			"background": "var(--wp--preset--color--background)",
+			"text": "var(--wp--preset--color--foreground)"
+		},
 		"elements": {
 			"h1": {
 				"typography": {

--- a/styles/pink.json
+++ b/styles/pink.json
@@ -1,0 +1,98 @@
+{
+	"version": 2,
+	"settings": {
+		"color": {
+			"duotone": [
+				{
+					"colors": [
+						"#000000",
+						"#FFFFFF"
+					],
+					"slug": "default-filter",
+					"name": "Default filter"
+				}
+			],
+			"palette": [
+				{
+					"slug": "foreground",
+					"color": "#000000",
+					"name": "Foreground"
+				},
+				{
+					"slug": "background",
+					"color": "#FFFFFF",
+					"name": "Background"
+				},
+				{
+					"slug": "primary",
+					"color": "#000000",
+					"name": "Primary"
+				},
+				{
+					"slug": "secondary",
+					"color": "#FFCCCC",
+					"name": "Secondary"
+				},
+				{
+					"slug": "tertiary",
+					"color": "#FFCCCC",
+					"name": "Tertiary"
+				}
+			]
+		},
+		"layout": {
+			"wideSize": "1060px"
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/image": {
+				"filter": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
+				}
+			},
+			"core/post-title": {
+				"typography": {
+					"fontWeight": "300"
+				}
+			},
+			"core/query-title": {
+				"typography": {
+					"fontWeight": "300"
+				}
+			},
+			"core/post-featured-image": {
+				"filter": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
+				}
+			},
+			"core/site-logo": {
+				"filter": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
+				}
+			}
+		},
+		"elements": {
+			"h1": {
+				"typography": {
+					"fontWeight": "300"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontWeight": "300"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontWeight": "300"
+				}
+			},
+			"h4": {
+				"typography": {
+					"fontWeight": "300"
+				}
+			}
+		}
+	}
+}

--- a/styles/red.json
+++ b/styles/red.json
@@ -30,5 +30,11 @@
 				}
 			]
 		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--background)",
+			"text": "var(--wp--preset--color--foreground)"
+		}
 	}
 }

--- a/styles/red.json
+++ b/styles/red.json
@@ -1,0 +1,34 @@
+{
+	"version": 2,
+	"settings": {
+		"color": {
+			"palette": [
+				{
+					"slug": "foreground",
+					"color": "#2E2927",
+					"name": "Foreground"
+				},
+				{
+					"slug": "background",
+					"color": "#ffffff",
+					"name": "Background"
+				},
+				{
+					"slug": "primary",
+					"color": "#7C290F",
+					"name": "Primary"
+				},
+				{
+					"slug": "secondary",
+					"color": "#FCF5ED",
+					"name": "Secondary"
+				},
+				{
+					"slug": "tertiary",
+					"color": "#FCF5ED",
+					"name": "Tertiary"
+				}
+			]
+		}
+	}
+}

--- a/styles/swiss.json
+++ b/styles/swiss.json
@@ -67,6 +67,10 @@
 				}
 			}
 		},
+		"color": {
+			"background": "var(--wp--preset--color--background)",
+			"text": "var(--wp--preset--color--foreground)"
+		},
 		"elements": {
 			"h1": {
 				"typography": {

--- a/styles/swiss.json
+++ b/styles/swiss.json
@@ -1,0 +1,106 @@
+{
+	"version": 2,
+	"settings": {
+		"color": {
+			"duotone": [
+				{
+					"colors": [
+						"#000000",
+						"#FFFFFF"
+					],
+					"slug": "default-filter",
+					"name": "Default filter"
+				}
+			],
+			"palette": [
+				{
+					"slug": "foreground",
+					"color": "#000000",
+					"name": "Foreground"
+				},
+				{
+					"slug": "background",
+					"color": "#FFFFFF",
+					"name": "Background"
+				},
+				{
+					"slug": "primary",
+					"color": "#D42731",
+					"name": "Primary"
+				},
+				{
+					"slug": "secondary",
+					"color": "#F4F4F2",
+					"name": "Secondary"
+				},
+				{
+					"slug": "tertiary",
+					"color": "#FFFFFF",
+					"name": "Tertiary"
+				}
+			]
+		},
+		"layout": {
+			"wideSize": "1060px"
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/image": {
+				"filter": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
+				}
+			},
+			"core/post-featured-image": {
+				"filter": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
+				}
+			},
+			"core/post-title": {
+				"typography": {
+					"fontWeight": "700"
+				}
+			},
+			"core/site-logo": {
+				"filter": {
+					"duotone": "var(--wp--preset--duotone--default-filter)"
+				}
+			}
+		},
+		"elements": {
+			"h1": {
+				"typography": {
+					"fontWeight": "700"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontWeight": "700"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontWeight": "700"
+				}
+			},
+			"h4": {
+				"typography": {
+					"fontWeight": "700"
+				}
+			},
+			"h5": {
+				"typography": {
+					"fontWeight": "700"
+				}
+			},
+			"h6": {
+				"typography": {
+					"fontWeight": "700"
+				}
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--system-font)"
+		}
+	}
+}


### PR DESCRIPTION
This is just to test out and refine alongside https://github.com/WordPress/gutenberg/pull/35619. 

It takes the theme.json files from https://github.com/WordPress/theme-experiments/pull/292 and adds their `json` files to a new `/styles` folder in the theme. It does not migrate over the template edits (since that's not actually a part of this PR), or the exact font changes (since it's impossible to enqueue new fonts in theme.json at the moment). 

## Screenshot

![theme-json](https://user-images.githubusercontent.com/1202812/148972124-cbabeac6-e749-4d51-a41b-44b13588a34c.gif)

