### PR TITLE
Add negative margins to top-level group and cover blocks

### DIFF
--- a/style.css
+++ b/style.css
@@ -99,6 +99,7 @@ a:active {
 body > .is-root-container,
 .edit-post-visual-editor__post-title-wrapper,
 .wp-block-group.alignfull,
+.wp-block-group.has-background,
 .wp-block-cover.alignfull,
 .is-root-container .wp-block[data-align="full"] > .wp-block-group,
 .is-root-container .wp-block[data-align="full"] > .wp-block-cover {

--- a/style.css
+++ b/style.css
@@ -110,8 +110,12 @@ body > .is-root-container,
 .wp-site-blocks .alignfull,
 .wp-site-blocks > .wp-block-group.has-background,
 .wp-site-blocks > .wp-block-cover,
+.wp-site-blocks > .wp-block-template-part > .wp-block-group.has-background,
+.wp-site-blocks > .wp-block-template-part > .wp-block-cover,
 body > .is-root-container > .wp-block-group.has-background,
 body > .is-root-container > .wp-block-cover,
+body > .is-root-container > .wp-block-template-part > .wp-block-group.has-background,
+body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 .is-root-container .wp-block[data-align="full"] {
 	margin-left: calc(-1 * var(--wp--custom--spacing--outer)) !important;
 	margin-right: calc(-1 * var(--wp--custom--spacing--outer)) !important;

--- a/style.css
+++ b/style.css
@@ -107,6 +107,10 @@ body > .is-root-container,
 }
 
 .wp-site-blocks .alignfull,
+.wp-site-blocks > .wp-block-group.has-background,
+.wp-site-blocks > .wp-block-cover,
+body > .is-root-container > .wp-block-group.has-background,
+body > .is-root-container > .wp-block-cover,
 .is-root-container .wp-block[data-align="full"] {
 	margin-left: calc(-1 * var(--wp--custom--spacing--outer)) !important;
 	margin-right: calc(-1 * var(--wp--custom--spacing--outer)) !important;


### PR DESCRIPTION
Fixes #330. 

I think we overlooked something important in #291: Top level Group blocks (when they have a background color) and Cover blocks should have negative margins applied in both the editor and the front end. 

This came up while watching a user struggle with how to make an edge-to-edge header with a solid color background. This _should_ be easy, but it wasn't. Our current rules only apply the negative margins to `alignfull` blocks, so they had to first add a top-level Group block in the site editor, set it to `Inherit default layout`, and then place a full-width group w/background color inside of that. It was not intuitive, and is the same hack noted in https://github.com/WordPress/twentytwentytwo/issues/330#issuecomment-1010018513. 

Group Blocks with a background color, and Cover blocks already come with have their own padding. So when they're on the top level of the site editor, they don't need to use the outer padding. They can just go edge-to-edge.

Doing this doesn't seem to have any negative effect on our existing layouts or patterns. 

## To Test: 

1. Add a top-level Group block in the site editor.
2. Make sure it has left-right padding as expected.
3. Add a background color to it.
4. Ensure that the color goes edge-to-edge, and still has inner padding. 
5. Add a top-level cover block, ensure that goes edge-to-edge too. 

Also, do a sweep of existing templates and patterns to ensure they're still behaving as intended. 

## Screenshots

Pattern Preview Before|Pattern Preview After
---|---
<img width="380" alt="Screen Shot 2022-01-13 at 8 52 24 AM" src="https://user-images.githubusercontent.com/1202812/149342498-1e446d98-7e6b-4ac6-8d55-0b2cdd5a2de3.png">|<img width="379" alt="Screen Shot 2022-01-13 at 8 51 59 AM" src="https://user-images.githubusercontent.com/1202812/149342526-bfa6c47f-6709-4c89-bbd2-2fe2b4343bd5.png">


**All blocks in these screenshots are at the top-level of the site editor:** 

Editor Before|Editor After
---|---
<img width="1027" alt="Screen Shot 2022-01-13 at 8 46 23 AM" src="https://user-images.githubusercontent.com/1202812/149341804-38a8b6e2-85ee-4636-b076-1e110697d3d4.png">|<img width="1027" alt="Screen Shot 2022-01-13 at 8 46 01 AM" src="https://user-images.githubusercontent.com/1202812/149341806-3d1dd88d-a722-4220-80e8-3123d5684b48.png">

Front-end Before|Front-end After
---|---
<img width="1027" alt="Screen Shot 2022-01-13 at 8 46 25 AM" src="https://user-images.githubusercontent.com/1202812/149341849-7e1bed28-db62-45dd-99f7-2e4db0b2b162.png">|<img width="1027" alt="Screen Shot 2022-01-13 at 8 45 58 AM" src="https://user-images.githubusercontent.com/1202812/149341851-da030951-b7ef-4b34-a025-7e07719650d6.png">

