### PR TITLE
Also allow stacking of negative margins in cover

### DIFF
--- a/style.css
+++ b/style.css
@@ -126,8 +126,8 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 .wp-site-blocks .wp-block-columns .wp-block-column .alignfull,
 .is-root-container .wp-block-columns .wp-block-column .wp-block[data-align="full"],
 /* We also want to avoid stacking negative margins. */
-.wp-site-blocks .alignfull:not(.wp-block-group) .alignfull,
-.is-root-container .wp-block[data-align="full"] > *:not(.wp-block-group) .wp-block[data-align="full"] {
+.wp-site-blocks .alignfull:not(.wp-block-group):not(.wp-block-cover) .alignfull,
+.is-root-container .wp-block[data-align="full"] > *:not(.wp-block-group):not(.wp-block-cover) .wp-block[data-align="full"] {
 	margin-left: auto !important;
 	margin-right: auto !important;
 	width: inherit;


### PR DESCRIPTION
**Description**

A fully aligned block inside a fully aligned cover-block needs to have double negative margins, because it has double positive paddings. If this makes sense ^_^' 

Just like the group block.

**Testing Instructions** 

1. Add a fully aligned group-block inside a fully aligned cover block.
2. See double horizontal padding.
