### PR TITLE
Try using __unstableLocation attribute to migrate over existing classic menu

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -27,6 +27,14 @@ if ( ! function_exists( 'twentytwentytwo_support' ) ) :
 		// Enqueue editor styles.
 		add_editor_style( 'style.css' );
 
+		// Add a menu location.
+		// Used only for migrating over classic menus.
+		register_nav_menus(
+			array(
+				'primary' => esc_html__( 'Primary menu', 'twentytwentytwo' ),
+			)
+		);
+
 	}
 
 endif;

--- a/parts/header.html
+++ b/parts/header.html
@@ -6,6 +6,8 @@
 <!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /--></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} /--></div>
+<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} -->
+<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+<!-- /wp:navigation --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/parts/header.html
+++ b/parts/header.html
@@ -6,8 +6,6 @@
 <!-- wp:site-title {"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}}} /--></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} -->
-<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-<!-- /wp:navigation --></div>
+<!-- wp:navigation {"__unstableLocation":"primary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->


### PR DESCRIPTION
This PR is a quick attempt to automatically migrate over a primary menu if one was set in a classic theme.

Technically, this seems to work in my testing, but it feels weird to lean on something that's clearly labeled "unstable." 😕

## To test: 

1. Start with a classic theme that uses a "Primary" menu location. (Most of the recent default themes do this). 
2. Assign a menu to that Primary location using the Customizer. 
3. Be sure to hit "Publish" to save your changes.
4. Switch to the Twenty Twenty-Two theme. 
5. Observe that the primary menu on the front end displays the same menu you chose in step 2.

## Video:

https://user-images.githubusercontent.com/1202812/150858000-74abb127-03df-4aa0-87c5-b0075bddab8e.mp4


